### PR TITLE
Remove redherring adapter

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -130,7 +130,6 @@ if config_env() == :prod do
 
   # SmsService
   config :bike_brigade, :sms_service,
-    adapter: BikeBrigade.SmsService.SmsService,
     status_callback_url: System.fetch_env!("TWILIO_STATUS_CALLBACK")
 end
 


### PR DESCRIPTION
The adapter is read by SmsService at compile time and this value is
ignored. It was set wrong, but luckily had no effect. Removing it
removes some of the surprise factor.

The confusing *runtime* configuration bit:
https://github.com/bikebrigade/dispatch/blob/fix-confusing-sms-service-config/config/runtime.exs#L132
```elixir
  config :bike_brigade, :sms_service,
    adapter: MODULE_THAT_DOESNT_EXIST,
    status_callback_url: System.fetch_env!("TWILIO_STATUS_CALLBACK")
```

The actual value that is used, which set and read at *compile* time:
https://github.com/bikebrigade/dispatch/blob/fix-confusing-sms-service-config/config/prod.exs#L12
```elixir
config :bike_brigade, :sms_service, adapter: BikeBrigade.SmsService.Twilio
```

Read the value from the config at *compile* and set the `@sms_service` attribute
https://github.com/bikebrigade/dispatch/blob/fix-confusing-sms-service-config/lib/bike_brigade/adapter.ex#L4-L5