### PR TITLE
Don't run importer on staging

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,9 +17,4 @@ config :bike_brigade, :media_storage,
   bucket: "bike-brigade-public",
   adapter: BikeBrigade.MediaStorage.GoogleMediaStorage
 
-# Importers
-config :bike_brigade, BikeBrigade.Importers.Runner,
-  start: true,
-  checkin_url: {:system, "IMPORTER_CHECKIN_URL"}
-
 config :logger, level: :info

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -76,6 +76,11 @@ if config_env() == :prod do
         max_batch_size: 50,
         metadata: [drop: [:hb_breadcrumbs]]
 
+      # Importers
+      config :bike_brigade, BikeBrigade.Importers.Runner,
+        start: true,
+        checkin_url: {:system, "IMPORTER_CHECKIN_URL"}
+
     :staging ->
       _app_name =
         System.get_env("FLY_APP_NAME") ||


### PR DESCRIPTION
Move importer setup from prod.exs to runtime.exs in the prod stanza, mostly so that it would start on staging. 