### PR TITLE
Create UI.table

### DIFF
--- a/lib/bike_brigade_web/live/components/ui.ex
+++ b/lib/bike_brigade_web/live/components/ui.ex
@@ -188,15 +188,16 @@ defmodule BikeBrigadeWeb.Components.UI do
   end
 
   def table(assigns) do
+    assigns = assign_new(assigns, :class, fn -> "" end)
     ~H"""
     <div class="flex flex-col py-4">
       <div class="py-2 -my-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
         <div class="inline-block min-w-full overflow-hidden align-middle border-b border-gray-200 shadow sm:rounded-lg">
-          <table class="min-w-full">
+          <table class={"min-w-full #{@class}"} >
             <thead>
               <tr>
                 <%= for th <- @th do %>
-                <th class={"px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50 #{Map.get(th, :class)}"}>
+                <th class={"text-xs font-medium leading-4 tracking-wider text-left text-gray-500 border-b border-gray-200 bg-gray-50 #{if Map.get(th, :uppercase, true), do: "uppercase"} #{Map.get(th, :padding, "px-6 py-3")} #{Map.get(th, :class)}"}>
                   <%= render_slot(th) %>
                 </th>
                 <% end %>
@@ -205,7 +206,7 @@ defmodule BikeBrigadeWeb.Components.UI do
             <%= for row <- @rows do %>
               <tr>
                 <%= for td <- @td do %>
-                  <td class={"px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap #{Map.get(td, :class)}"}>
+                  <td class={"text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap #{Map.get(td, :padding, "px-6 py-4")} #{Map.get(td, :class)}"}>
                     <%= render_slot(td, row) %>
                   </td>
                 <% end %>

--- a/lib/bike_brigade_web/live/components/ui.ex
+++ b/lib/bike_brigade_web/live/components/ui.ex
@@ -186,4 +186,35 @@ defmodule BikeBrigadeWeb.Components.UI do
     </div>
     """
   end
+
+  def table(assigns) do
+    ~H"""
+    <div class="flex flex-col py-4">
+      <div class="py-2 -my-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+        <div class="inline-block min-w-full overflow-hidden align-middle border-b border-gray-200 shadow sm:rounded-lg">
+          <table class="min-w-full">
+            <thead>
+              <tr>
+                <%= for th <- @th do %>
+                <th class={"px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50 #{Map.get(th, :class)}"}>
+                  <%= render_slot(th) %>
+                </th>
+                <% end %>
+              </tr>
+            </thead>
+            <%= for row <- @rows do %>
+              <tr>
+                <%= for td <- @td do %>
+                  <td class={"px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap #{Map.get(td, :class)}"}>
+                    <%= render_slot(td, row) %>
+                  </td>
+                <% end %>
+              </tr>
+            <% end %>
+          </table>
+        </div>
+      </div>
+    </div>
+    """
+  end
 end

--- a/lib/bike_brigade_web/live/item_live/index.html.heex
+++ b/lib/bike_brigade_web/live/item_live/index.html.heex
@@ -9,54 +9,39 @@
       return_to={Routes.item_index_path(@socket, :index)}/>
   </UI.modal>
 <% end %>
-<div class="flex flex-col py-4">
-  <div class="py-2 -my-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-    <div class="inline-block min-w-full overflow-hidden align-middle border-b border-gray-200 shadow sm:rounded-lg">
-      <table class="min-w-full table-fixed">
-        <thead>
-          <tr>
-            <th class="w-1/3 px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Program
-            </th>
-            <th class="w-1/3 px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Name
-            </th>
-            <th class="w-full px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Description
-            </th>
-             <th class="w-1/3 px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Category
-            </th>
-             <th class="px-3 py-3 border-b border-gray-200 bg-gray-50">
-              <C.button patch_to={ Routes.item_index_path(@socket, :new)}>
-              New Item
-              </C.button>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="bg-white">
-          <%= for item <- @items do %>
-            <tr id={"item-#{item.id}"}>
-              <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200">
-                <%= item.program && item.program.name %>
-              </td>
-              <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200">
-                <%= item.name %>
-              </td>
-              <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200">
-                <%= item.description %>
-              </td>
-              <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200">
-                <%= item.category %>
-              </td>
-              <td class="px-6 py-4 text-sm font-medium leading-5 text-right border-b border-gray-200 whitespace-nowrap">
-              <%= live_patch "Edit", to: Routes.item_index_path(@socket, :edit, item), class: "text-indigo-600 hover:text-indigo-900" %>
-              <%= link "Delete", to: "#", phx_click: "delete", phx_value_id: item.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
-            </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </div>
-</div>
+<UI.table class="table-fixed" rows={@items}>
+  <:th class="w-1/3">
+    Program
+  </:th>
+  <:th class="w-1/3">
+    Name
+  </:th>
+  <:th class="w-full">
+    Description
+  </:th>
+  <:th class="w-1/3">
+    Category
+  </:th>
+  <:th padding="px-3 py-3" uppercase={false}>
+    <C.button patch_to={ Routes.item_index_path(@socket, :new)}>
+    New Item
+    </C.button>
+  </:th>
+
+  <:td let={item}>
+    <%= item.program && item.program.name %>
+  </:td>
+  <:td let={item}>
+    <%= item.name %>
+  </:td>
+  <:td let={item}>
+    <%= item.description %>
+  </:td>
+  <:td let={item}>
+    <%= item.category %>
+  </:td>
+  <:td let={item}>
+    <%= live_patch "Edit", to: Routes.item_index_path(@socket, :edit, item), class: "text-indigo-600 hover:text-indigo-900" %>
+    <%= link "Delete", to: "#", phx_click: "delete", phx_value_id: item.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
+  </:td>
+</UI.table>

--- a/lib/bike_brigade_web/live/program_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/program_live/form_component.html.heex
@@ -81,45 +81,36 @@
       <%= label f, :default_item_id, class: "block text-sm font-medium leading-5 text-gray-700" do %>
         Items
       <% end %>
-      <table class="min-w-full table-fixed">
-        <thead>
-          <tr>
-            <th class="w-1/3 px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Name
-            </th>
-            <th class="w-full px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Description
-            </th>
-              <th class="w-1/3 px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Category
-            </th>
-            <th class="flex justify-end w-32 px-3 py-3 border-b border-gray-200 bg-gray-50">
-              <C.button size={:small} patch_to={Routes.program_index_path(@socket, :new_item, @program.id)}>
-                New Item
-              </C.button>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="bg-white">
-          <%= for item <- @program.items do %>
-            <tr id={"item-#{item.id}"}>
-              <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200">
+      <UI.table class="table-fixed" rows={@program.items }>
+        <:th class="w-1/3">
+          Name
+        </:th>
+        <:th class="w-full">
+          Description
+        </:th>
+        <:th class="w-1/3">
+          Category
+        </:th>
+        <:th class="flex justify-end w-32" padding="px-3 py-3" uppercase={false}>
+          <C.button size={:xsmall} patch_to={Routes.program_index_path(@socket, :new_item, @program.id)}>
+            New Item
+          </C.button>
+        </:th>
+              <:td let={item}>
                 <%= item.name %>
-              </td>
-              <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200">
+              </:td>
+              <:td let={item}>
                 <%= item.description %>
-              </td>
-              <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200">
+              </:td>
+              <:td let={item}>
                 <%= item.category %>
-              </td>
-              <td class="px-6 py-4 text-sm font-medium leading-5 text-right border-b border-gray-200 whitespace-nowrap">
+              </:td>
+              <:td class="text-right" let={item}>
               <%= live_patch "Edit", to: Routes.program_index_path(@socket, :edit_item, @program.id, item.id), class: "text-indigo-600 hover:text-indigo-900" %>
               <%#= link "Delete", to: "#", phx_click: "delete", phx_value_id: item.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
-            </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+            </:td>
+
+      </UI.table>
     </div>
   <% end %>
 

--- a/lib/bike_brigade_web/live/program_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/program_live/form_component.html.heex
@@ -96,20 +96,20 @@
             New Item
           </C.button>
         </:th>
-              <:td let={item}>
-                <%= item.name %>
-              </:td>
-              <:td let={item}>
-                <%= item.description %>
-              </:td>
-              <:td let={item}>
-                <%= item.category %>
-              </:td>
-              <:td class="text-right" let={item}>
-              <%= live_patch "Edit", to: Routes.program_index_path(@socket, :edit_item, @program.id, item.id), class: "text-indigo-600 hover:text-indigo-900" %>
-              <%#= link "Delete", to: "#", phx_click: "delete", phx_value_id: item.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
-            </:td>
 
+        <:td let={item}>
+          <%= item.name %>
+        </:td>
+        <:td let={item}>
+          <%= item.description %>
+        </:td>
+        <:td let={item}>
+          <%= item.category %>
+        </:td>
+        <:td class="text-right" let={item}>
+        <%= live_patch "Edit", to: Routes.program_index_path(@socket, :edit_item, @program.id, item.id), class: "text-indigo-600 hover:text-indigo-900" %>
+        <%#= link "Delete", to: "#", phx_click: "delete", phx_value_id: item.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
+        </:td>
       </UI.table>
     </div>
   <% end %>

--- a/lib/bike_brigade_web/live/program_live/index.html.heex
+++ b/lib/bike_brigade_web/live/program_live/index.html.heex
@@ -1,11 +1,11 @@
 <%= if @live_action in [:new, :edit] do %>
   <UI.modal show id={:edit} return_to={Routes.program_index_path(@socket, :index)} >
     <:title><%= Atom.to_string(@live_action) |> String.capitalize() %> Program</:title>
-    <.live_component 
-      module={BikeBrigadeWeb.ProgramLive.FormComponent} 
-      id={@program.id || :new} 
-      action={@live_action} 
-      program={@program} 
+    <.live_component
+      module={BikeBrigadeWeb.ProgramLive.FormComponent}
+      id={@program.id || :new}
+      action={@live_action}
+      program={@program}
       return_to={Routes.program_index_path(@socket, :index)}/>
   </UI.modal>
 <% end %>
@@ -13,85 +13,70 @@
 <%= if @live_action in [:new_item, :edit_item] do %>
   <UI.modal show id={:edit_item} return_to={Routes.program_index_path(@socket, :edit, @program)}>
     <:title>Edit Item</:title>
-    <.live_component 
-      module={BikeBrigadeWeb.ProgramLive.ItemFormComponent} 
-      id={@item.id || :new} 
-      action={@live_action} 
-      program={@program} 
+    <.live_component
+      module={BikeBrigadeWeb.ProgramLive.ItemFormComponent}
+      id={@item.id || :new}
+      action={@live_action}
+      program={@program}
       item={@item}
       return_to={Routes.program_index_path(@socket, :index)}/>
   </UI.modal>
 <% end %>
 
-<div class="flex flex-col py-4">
-  <div class="py-2 -my-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-    <div class="inline-block min-w-full overflow-hidden align-middle border-b border-gray-200 shadow sm:rounded-lg">
-      <table class="min-w-full">
-        <thead>
-          <tr>
-             <th class="px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Name
-            </th>
-            <th class="px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Campaigns
-            </th>
-            <th class="px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Latest Campaign
-            </th>
-            <th class="px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Schedule
-            </th>
-            <th class="px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Lead
-            </th>
-            <th class="flex justify-end px-3 py-3 border-b border-gray-200 bg-gray-50">
-              <C.button patch_to={Routes.program_index_path(@socket, :new)} %>
-                New Program
-              </C.button>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="bg-white">
-        <%= for program <- @programs do %>
-          <tr id={program.id}>
-            <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap">
-                <%= live_redirect program.name, to: Routes.program_show_path(@socket, :show, program),  class: "pl-2 text-indigo-600 hover:text-indigo-900" %>
-                <%= if !program.active do %>
-                  <span class="inline-block px-2 ml-2 text-xs border rounded-full">
-                    Inactive
-                  </span>
-                <% end %>
-            </td>
-            <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap">
-              <%= program.campaign_count %>
-            </td>
-            <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap">
-              <%= if latest_campaign = program.latest_campaign do %>
-                <%= live_redirect to: Routes.campaign_show_path(@socket, :show, latest_campaign), class: "inline-flex hover:bg-indigo-100" do %>
-                  <C.date date={latest_campaign.delivery_start || latest_campaign.delivery_date} />
-                <% end %>
-              <% end %>
-            </td>
-            <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap">
-              <%= if program.schedules != [] do %>
-                <%= for s <- program.schedules do %>
-                  <div><%= ProgramForm.Schedule.from_program_schedule(s) %></div>
-                <% end %>
-              <% else %>
-                N/A
-              <% end %>
-            </td>
-            <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap">
-              <%= if program.lead, do: program.lead.name, else: "N/A" %>
-            </td>
-            <td class="px-6 py-4 text-sm font-medium leading-5 text-right border-b border-gray-200 whitespace-nowrap">
-              <%= live_patch "Edit", to: Routes.program_index_path(@socket, :edit, program), class: "text-indigo-600 hover:text-indigo-900" %>
-              <%#= link "Delete", to: "#", phx_click: "delete", phx_value_id: campaign.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
-            </td>
-          </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </div>
-</div>
+<UI.table rows={@programs}>
+  <:th>
+    Name
+  </:th>
+  <:th>
+    Campaigns
+  </:th>
+  <:th>
+    Latest Campaign
+  </:th>
+  <:th>
+    Schedule
+  </:th>
+  <:th>
+    Lead
+  </:th>
+  <:th class="flex justify-end" padding="px-3 py-3" uppercase={false}>
+    <C.button patch_to={Routes.program_index_path(@socket, :new)} %>
+      New Program
+    </C.button>
+  </:th>
+
+  <:td let={program}>
+    <%= live_redirect program.name, to: Routes.program_show_path(@socket, :show, program),  class: "pl-2 text-indigo-600 hover:text-indigo-900" %>
+    <%= if !program.active do %>
+      <span class="inline-block px-2 ml-2 text-xs border rounded-full">
+        Inactive
+      </span>
+    <% end %>
+  </:td>
+  <:td let={program}>
+    <%= program.campaign_count %>
+  </:td>
+  <:td let={program}>
+    <%= if latest_campaign = program.latest_campaign do %>
+      <%= live_redirect to: Routes.campaign_show_path(@socket, :show, latest_campaign), class: "inline-flex hover:bg-indigo-100" do %>
+        <C.date date={latest_campaign.delivery_start || latest_campaign.delivery_date} />
+      <% end %>
+    <% end %>
+  </:td>
+  <:td let={program}>
+    <%= if program.schedules != [] do %>
+      <%= for s <- program.schedules do %>
+        <div><%= ProgramForm.Schedule.from_program_schedule(s) %></div>
+      <% end %>
+    <% else %>
+      N/A
+    <% end %>
+  </:td>
+  <:td let={program}>
+    <%= if program.lead, do: program.lead.name, else: "N/A" %>
+  </:td>
+  <:td let={program} class="px-4 py-3 text-right">
+    <%= live_patch "Edit", to: Routes.program_index_path(@socket, :edit, program), class: "text-indigo-600 hover:text-indigo-900" %>
+    <%#= link "Delete", to: "#", phx_click: "delete", phx_value_id: campaign.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
+  </:td>
+</UI.table>

--- a/lib/bike_brigade_web/live/program_live/show.html.heex
+++ b/lib/bike_brigade_web/live/program_live/show.html.heex
@@ -14,58 +14,34 @@
   </h1>
   <C.button patch_to={Routes.program_show_path(@socket, :edit, @program)}>Edit</C.button>
 </div>
+<UI.table class="table-fixed" rows={@program.campaigns}>
+  <:th>Date</:th>
+  <:th>Time</:th>
+  <:th>Riders</:th>
+  <:th>Deliveries</:th>
+  <:th class="flex justify-end" padding="px-3 py-3" uppercase={false}>
+    <C.button redirect_to={Routes.campaign_index_path(@socket, :new)}>
+      New Campaign
+    </C.button>
+  </:th>
 
-<div class="flex flex-col py-4">
-  <div class="py-2 -my-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-    <div class="inline-block min-w-full align-middle border-b border-gray-200 shadow sm:rounded-lg">
-      <table class="min-w-full table-fixed">
-        <thead>
-          <tr>
-            <th class="w-24 px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Date
-            </th>
-            <th class="w-24 px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Time
-            </th>
-            <th class="w-24 px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Riders
-            </th>
-            <th class="w-24 px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Deliveries
-            </th>
-            <th class="flex justify-end px-3 py-3 border-b border-gray-200 bg-gray-50">
-              <C.button redirect_to={Routes.campaign_index_path(@socket, :new)}>
-                New Campaign
-              </C.button>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="bg-white">
-        <%= for campaign <- @program.campaigns do %>
-          <tr id={campaign.id}>
-            <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap">
-              <div class="flex items-center space-x-1">
-                <C.date date={campaign_date(campaign)} link_to={Routes.campaign_show_path(@socket, :show, campaign)}/>
-              </div>
-            </td>
-            <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200">
-              <div class="w-24 truncate"><%= if campaign.delivery_start, do: time_interval(campaign.delivery_start, campaign.delivery_end), else: campaign.pickup_window %></div>
-            </td>
-            <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap">
-              <%= campaign.total_riders %>
-            </td>
-            <td class="px-6 py-4 text-sm leading-5 text-gray-500 border-b border-gray-200 whitespace-nowrap">
-              <%= campaign.total_tasks %>
-            </td>
-            <td class="px-6 py-4 text-sm font-medium leading-5 text-right border-b border-gray-200 whitespace-nowrap">
-              <%= live_redirect "Edit", to: Routes.campaign_index_path(@socket, :edit, campaign), class: "text-indigo-600 hover:text-indigo-900" %>
-              <%= link "Delete", to: "#", phx_click: "delete", phx_value_id: campaign.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
-            </td>
-          </tr>
-          <% end %>
-        </tbody>
-      </table>
+  <:td let={campaign}>
+     <div class="flex items-center space-x-1">
+      <C.date date={campaign_date(campaign)} link_to={Routes.campaign_show_path(@socket, :show, campaign)}/>
     </div>
+  </:td>
+  <:td let={campaign}>
+    <div class="w-24 truncate"><%= if campaign.delivery_start, do: time_interval(campaign.delivery_start, campaign.delivery_end), else: campaign.pickup_window %></div>
+  </:td>
+  <:td let={campaign}>
+    <%= campaign.total_riders %>
+  </:td>
+  <:td let={campaign}>
+    <%= campaign.total_tasks %>
+  </:td>
+  <:td let={campaign} class="text-right">
+    <%= live_redirect "Edit", to: Routes.campaign_index_path(@socket, :edit, campaign), class: "text-indigo-600 hover:text-indigo-900" %>
+    <%= link "Delete", to: "#", phx_click: "delete", phx_value_id: campaign.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
+  </:td>
+</UI.table>
 
-  </div>
-</div>

--- a/lib/bike_brigade_web/live/stats_live/leaderboard.html.heex
+++ b/lib/bike_brigade_web/live/stats_live/leaderboard.html.heex
@@ -41,7 +41,7 @@
               End Date
             <% end %>
             <%= date_input f, :end_date,
-              class: "w-full py-2.5 pl-4 pr-4 text-sm font-medium leading-none text-gray-600 rounded-lg shadow-sm focus:outline-none focus:shadow-outline cursor-pointer" %>    
+              class: "w-full py-2.5 pl-4 pr-4 text-sm font-medium leading-none text-gray-600 rounded-lg shadow-sm focus:outline-none focus:shadow-outline cursor-pointer" %>
             <%= error_tag f, :end_date %>
           </div>
         </div>
@@ -52,72 +52,59 @@
     </div>
   </div>
   </.form>
-  <div class="mt-3 overflow-x-auto sm:-mx-6 lg:-mx-8">
-    <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-      <div class="overflow-hidden border-b border-gray-200 shadow sm:rounded-lg">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th scope="col" class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">
-                <div class="inline-flex align-top">
-                  Name
-                  <.sort_icon field={:rider_name} options={@options} />
-                </div>
-              </th>
-              <th scope="col" class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase ">
-                Email
-              </th>
-              <th scope="col" class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase ">
-                <div class="inline-flex align-baseline">
-                  Campaigns
-                  <.sort_icon field={:campaigns} options={@options} />
-                </div>
-              </th>
-              <th scope="col" class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase ">
-                <div class="inline-flex">
-                  Deliveries
-                  <.sort_icon field={:deliveries} options={@options} />
-                </div>
-              </th>
-              <th scope="col" class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase ">
-                <div class="inline-flex">
-                  Distance
-                  <.sort_icon field={:distance} options={@options} />
-                </div>
-              </th>
-              <th scope="col" class="relative px-6 py-3">
-                <span class="sr-only">Message</span>
-              </th>
-            </tr>
-          </thead>
-          <tbody class="bg-white divide-y divide-gray-200">
-            <%= for {rider, campaigns, tasks, distance} <- @stats do %>
-            <tr>
-              <td class="px-6 py-4 text-sm font-medium text-gray-900 whitespace-nowrap">
-                <%= rider.name %>
-              </td>
-              <td class="px-6 py-4 text-sm font-medium text-gray-900 whitespace-nowrap">
-                <%= link rider.email, to: "mailto:#{rider.email}", class: "text-indigo-600 hover:text-indigo-900"%>
-              </td>
-              <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">
-                <%= campaigns %>
-              </td>
-              <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">
-                <%= tasks %>
-              </td>
-              <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">
-                <%= round_distance(distance) %> km
-              </td>
-              <td class="px-6 py-4 text-sm font-medium text-right whitespace-nowrap">
-                <C.button size={:xsmall} patch-to={Routes.sms_message_index_path(@socket, :show, rider.id)}>
-                  Message
-                </C.button>
-              </td>
-            </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    </div>
+  <div class="mt-3 overflow-x-auto align-middle sm:-mx-6 lg:-mx-8 sm:px-6 lg:px-8">
+    <UI.table rows={@stats}>
+      <:th>
+        <div class="inline-flex align-top">
+          Name
+          <.sort_icon field={:rider_name} options={@options} />
+        </div>
+      </:th>
+      <:th>
+        Email
+      </:th>
+      <:th>
+        <div class="inline-flex align-baseline">
+          Campaigns
+          <.sort_icon field={:campaigns} options={@options} />
+        </div>
+      </:th>
+      <:th>
+        <div class="inline-flex">
+          Deliveries
+          <.sort_icon field={:deliveries} options={@options} />
+        </div>
+      </:th>
+      <:th>
+        <div class="inline-flex">
+          Distance
+          <.sort_icon field={:distance} options={@options} />
+        </div>
+      </:th>
+      <:th>
+        <span class="sr-only">Message</span>
+      </:th>
+
+      <:td let={{rider, campaigns, tasks, distance}}>
+        <%= rider.name %>
+      </:td>
+      <:td let={{rider, campaigns, tasks, distance}}>
+        <%= link rider.email, to: "mailto:#{rider.email}", class: "text-indigo-600 hover:text-indigo-900"%>
+      </:td>
+      <:td let={{rider, campaigns, tasks, distance}}>
+        <%= campaigns %>
+      </:td>
+      <:td let={{rider, campaigns, tasks, distance}}>
+        <%= tasks %>
+      </:td>
+      <:td let={{rider, campaigns, tasks, distance}}>
+        <%= round_distance(distance) %> km
+      </:td>
+      <:td let={{rider, campaigns, tasks, distance}}>
+        <C.button size={:xsmall} patch-to={Routes.sms_message_index_path(@socket, :show, rider.id)}>
+          Message
+        </C.button>
+      </:td>
+    </UI.table>
   </div>
 </div>

--- a/lib/bike_brigade_web/live/user_live/index.html.heex
+++ b/lib/bike_brigade_web/live/user_live/index.html.heex
@@ -1,63 +1,46 @@
 <%= if @live_action in [:new, :edit] do %>
   <UI.modal show id={:edit} return_to={Routes.user_index_path(@socket, :index)} >
     <:title><%= Atom.to_string(@live_action) |> String.capitalize() %> Dispatcherlive</:title>
-    <.live_component 
-      module={BikeBrigadeWeb.UserLive.FormComponent} 
-      id={@user.id || :new} 
-      action={@live_action} 
-      user={@user} 
+    <.live_component
+      module={BikeBrigadeWeb.UserLive.FormComponent}
+      id={@user.id || :new}
+      action={@live_action}
+      user={@user}
       return_to={Routes.user_index_path(@socket, :index)}/>
   </UI.modal>
 <% end %>
-<div class="flex flex-col h-full">
-  <div class="py-2 -my-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-    <div class="inline-block min-w-full overflow-hidden align-middle border-b border-gray-200 shadow sm:rounded-lg">
-      <table class="min-w-full">
-        <thead>
-          <tr>
-            <th
-              class="px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Name
-            </th>
-            <th
-              class="px-6 py-3 text-xs font-medium leading-4 tracking-wider text-left text-gray-500 uppercase border-b border-gray-200 bg-gray-50">
-              Phone
-            </th>
-            <th class="flex justify-end px-3 py-3 border-b border-gray-200 bg-gray-50">
-              <C.button patch_to={Routes.user_index_path(@socket, :new)}>
-                Create new dispatcher
-              </C.button>
-            </th>
-          </tr>
-        </thead>
-        <tbody id="users" class="bg-white">
-          <%= for user <- @users do %>
-          <tr>
-            <td class="px-6 py-4 border-b border-gray-200 whitespace-nowrap">
-              <div class="flex items-center">
-                <div class="flex-shrink-0 w-10 h-10">
-                  <img class="w-10 h-10 rounded-full" src={gravatar(user.email)}
-                    alt="" />
-                </div>
-                <div class="ml-4 ">
-                  <div class="text-sm font-medium leading-5 text-gray-900"><%= user.name %>
-                  </div>
-                  <div class="text-sm leading-5 text-gray-500"><%= user.email %>
-                  </div>
-                </div>
-              </div>
-            </td>
-            <td class="px-6 py-4 border-b border-gray-200 whitespace-nowrap">
-              <%= user.phone %>
-            </td>
-            <td class="px-6 py-4 text-sm font-medium leading-5 text-right border-b border-gray-200 whitespace-nowrap">
-              <%= live_patch "Edit", to: Routes.user_index_path(@socket, :edit, user),  class: "pl-2 text-indigo-600 hover:text-indigo-900" %>
-              <%= link "Delete", to: "#", phx_click: "delete", phx_value_id: user.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
-            </td>
-          </tr>
-          <% end %>
-        </tbody>
-      </table>
+<UI.table rows={@users}>
+  <:th>
+    Name
+  </:th>
+  <:th>
+    Phone
+  </:th>
+  <:th class="flex justify-end" padding="px-3 py-3" uppercase={false}>
+    <C.button patch_to={Routes.user_index_path(@socket, :new)}>
+      Create new dispatcher
+    </C.button>
+  </:th>
+
+  <:td let={user}>
+    <div class="flex items-center">
+      <div class="flex-shrink-0 w-10 h-10">
+        <img class="w-10 h-10 rounded-full" src={gravatar(user.email)}
+          alt="" />
+      </div>
+      <div class="ml-4 ">
+        <div class="text-sm font-medium leading-5 text-gray-900"><%= user.name %>
+        </div>
+        <div class="text-sm leading-5 text-gray-500"><%= user.email %>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
+  </:td>
+  <:td let={user}>
+    <%= user.phone %>
+  </:td>
+  <:td class="text-right" let={user}>
+    <%= live_patch "Edit", to: Routes.user_index_path(@socket, :edit, user),  class: "pl-2 text-indigo-600 hover:text-indigo-900" %>
+    <%= link "Delete", to: "#", phx_click: "delete", phx_value_id: user.id, data: [confirm: "Are you sure?"], class: "pl-2 text-indigo-600 hover:text-indigo-900"  %>
+  </:td>
+</UI.table>


### PR DESCRIPTION
This PR rewrites most of the tables to use `UI.table` which is a component that abstracts out most of the css for tables

What's missing
- the printable tables: they use some css tricks so may as well keep these seperate
- opportunities: there's a component for editing the row inline,

