### PR TITLE
Allow a different pg username to be set in .env file

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,7 @@ config :bike_brigade, :app_env, "development"
 
 # Configure your database
 config :bike_brigade, BikeBrigade.Repo,
-  username: "postgres",
+  username: System.get_env("POSTGRES_USERNAME") || "postgres",
   password: "postgres",
   database: "bike_brigade_dev",
   hostname: "localhost",


### PR DESCRIPTION
I hit the `ERROR 42501 (insufficient_privilege)` whenever I forget to rename `postgres` => `jennablumenthal` (aka all the time). This makes my workflow slightly easier (and I don't think should break anything else?).