### PR TITLE
CSS fix to campaign list

### DIFF
--- a/lib/bike_brigade_web/live/campaign_live/index.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/index.html.heex
@@ -51,11 +51,11 @@
       <%= for c <- campaigns do %>
         <li id={c.id}>
           <div class="px-4 py-4">
-            <div class="flex items-center justify-between">
-              <div class="flex items-center space-x-1">
+            <div class="items-center justify-between md:flex">
+              <div class="flex items-center mb-2 space-x-1">
                 <%= live_redirect name(c), to: Routes.campaign_show_path(@socket, :show, c),  class: "link text-sm font-medium" %>
               </div>
-              <div class="flex flex-shrink-0 space-x-2">
+              <div class="flex-shrink-0 space-y-1 md:space-x-2 md:flex">
                 <C.button size={:xsmall} color={:white} patch_to={Routes.campaign_index_path(@socket, :edit, c)}>
                   Edit
                 </C.button>


### PR DESCRIPTION
Make campaign name and buttons stack on mobile to prevent content from being wider than screen

![image](https://user-images.githubusercontent.com/1443657/153038909-c51cba2b-9bca-489f-af48-301e62aba873.png)
