### PR TITLE
Refactor queries in delivery.ex

### DIFF
--- a/lib/bike_brigade/delivery/campaign.ex
+++ b/lib/bike_brigade/delivery/campaign.ex
@@ -11,6 +11,8 @@ defmodule BikeBrigade.Delivery.Campaign do
 
   alias BikeBrigade.Location
 
+  alias BikeBrigade.Stats.CampaignStats
+
   defenum(RiderSpreadsheetLayout, non_foodshare: 0, foodshare: 1)
 
   @fields [
@@ -74,15 +76,12 @@ defmodule BikeBrigade.Delivery.Campaign do
     has_many :campaign_riders, CampaignRider
     many_to_many :riders, Rider, join_through: CampaignRider
 
-    field :total_riders, :integer, virtual: true
-    field :total_tasks, :integer, virtual: true
+    has_one :stats, CampaignStats
 
     field :delivery_url_token, :string, virtual: true
 
     has_one :campaign_latest_message, CampaignLatestMessage
     has_one :latest_message, through: [:campaign_latest_message, :sms_message]
-
-
 
     timestamps()
   end

--- a/lib/bike_brigade/delivery/campaign.ex
+++ b/lib/bike_brigade/delivery/campaign.ex
@@ -5,10 +5,9 @@ defmodule BikeBrigade.Delivery.Campaign do
   import EctoEnum
 
   alias BikeBrigade.Riders.Rider
-  alias BikeBrigade.Delivery.{Task, CampaignRider, Program}
+  alias BikeBrigade.Delivery.{Task, CampaignRider, Program, CampaignLatestMessage}
 
   alias BikeBrigade.Messaging
-  alias BikeBrigade.Messaging.SmsMessage
 
   alias BikeBrigade.Location
 
@@ -80,8 +79,10 @@ defmodule BikeBrigade.Delivery.Campaign do
 
     field :delivery_url_token, :string, virtual: true
 
-    #  field :campaign_message_id, :integer, virtual: true
-    belongs_to :latest_message, SmsMessage, define_field: false
+    has_one :campaign_latest_message, CampaignLatestMessage
+    has_one :latest_message, through: [:campaign_latest_message, :sms_message]
+
+
 
     timestamps()
   end

--- a/lib/bike_brigade/delivery/campaign_latest_message.ex
+++ b/lib/bike_brigade/delivery/campaign_latest_message.ex
@@ -1,0 +1,12 @@
+defmodule BikeBrigade.Delivery.CampaignLatestMessage do
+  use BikeBrigade.Schema
+
+  alias BikeBrigade.Delivery.Campaign
+  alias BikeBrigade.Messaging.SmsMessage
+
+  @primary_key false
+  schema "campaigns_latest_sms_messages" do
+    belongs_to :campaign, Campaign, primary_key: true
+    belongs_to :sms_message, SmsMessage
+  end
+end

--- a/lib/bike_brigade/delivery/program.ex
+++ b/lib/bike_brigade/delivery/program.ex
@@ -6,6 +6,8 @@ defmodule BikeBrigade.Delivery.Program do
 
   alias BikeBrigade.Delivery.{Item, Campaign, ProgramLatestCampaign}
 
+  alias BikeBrigade.Stats.CampaignStats
+
   defenum(SpreadsheetLayout,
     foodshare: "foodshare",
     map: "map"
@@ -38,13 +40,14 @@ defmodule BikeBrigade.Delivery.Program do
     field :start_date, :date
     embeds_many :schedules, Schedule, on_replace: :delete
 
-    field :campaign_count, :integer, virtual: true
     has_one :program_latest_campaign, ProgramLatestCampaign
     has_one :latest_campaign, through: [:program_latest_campaign, :campaign]
 
+    has_one :stats, CampaignStats, where: [campaign_id: nil]
 
     belongs_to :lead, BikeBrigade.Accounts.User, on_replace: :nilify
-    has_many :campaigns, Campaign
+    has_many :campaigns, Campaign, preload_order: [desc: :delivery_start]
+
     has_many :items, Item
     belongs_to :default_item, Campaign
 

--- a/lib/bike_brigade/scheduled_messenger.ex
+++ b/lib/bike_brigade/scheduled_messenger.ex
@@ -16,15 +16,14 @@ defmodule BikeBrigade.ScheduledMessenger do
   def handle_info(:send_messages, state) do
     Repo.transaction(
       fn ->
-        unsent_messages = Messaging.list_unsent_scheduled_messages(lock: true, log: false)
+        unsent_messages =
+          Messaging.list_unsent_scheduled_messages(lock: true, log: false)
+          |> Repo.preload(:campaign)
 
         for s <- unsent_messages do
           Logger.info("Sending scheduled messages for campaign #{s.campaign_id}")
 
-          # We have some non-decoupled preloads in get_campaign so we load it here instead of joining
-          # TODO: make this work with joins and preloads where we need things
-          c = Delivery.get_campaign(s.campaign_id)
-          Delivery.send_campaign_messages(c)
+          Delivery.send_campaign_messages(s.campaign)
 
           Repo.delete(s)
         end

--- a/lib/bike_brigade/stats/campaign_stats.ex
+++ b/lib/bike_brigade/stats/campaign_stats.ex
@@ -1,0 +1,17 @@
+defmodule BikeBrigade.Stats.CampaignStats do
+  use BikeBrigade.Schema
+
+  alias BikeBrigade.Riders.Rider
+  alias BikeBrigade.Delivery.Program
+
+  @primary_key false
+  schema "campaign_stats" do
+    field :task_count, :integer, default: 0
+    field :rider_count, :integer, default: 0
+    field :total_distance, :integer, default: 0
+    field :campaign_count, :integer, default: 0
+
+    belongs_to :campaign, Rider
+    belongs_to :program, Program
+  end
+end

--- a/lib/bike_brigade_web/live/campaign_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_live/index.ex
@@ -95,7 +95,7 @@ defmodule BikeBrigadeWeb.CampaignLive.Index do
   end
 
   defp fetch_campaigns(current_week) do
-    Delivery.list_campaigns(current_week)
+    Delivery.list_campaigns(current_week, preload: [:program, :stats, :latest_message])
     |> Enum.reverse()
     |> Utils.ordered_group_by(&(LocalizedDateTime.to_date(&1.delivery_start)))
     |> Enum.reverse()

--- a/lib/bike_brigade_web/live/campaign_live/index.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/index.html.heex
@@ -75,11 +75,11 @@
                 </p>
                 <p class="flex items-center mt-2 text-sm text-gray-500 sm:mt-0 sm:ml-6">
                   <C.Icons.maki_bicycle_share class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"/>
-                  <%= c.total_riders %>
+                  <%= c.stats.rider_count %>
                 </p>
                 <p class="flex items-center mt-2 text-sm text-gray-500 sm:mt-0 sm:ml-6">
                   <Heroicons.Outline.shopping_bag class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400" />
-                  <%= c.total_tasks %>
+                  <%= c.stats.task_count %>
                 </p>
               </div>
               <div class="flex items-center mt-2 text-sm text-gray-500 sm:mt-0">

--- a/lib/bike_brigade_web/live/campaign_live/map_component.ex
+++ b/lib/bike_brigade_web/live/campaign_live/map_component.ex
@@ -7,13 +7,13 @@ defmodule BikeBrigadeWeb.CampaignLive.MapComponent do
 
   @impl true
   def update(assigns, socket) do
-    %{campaign: campaign, tasks_query: tasks_query, riders_query: riders_query} = assigns
+    %{tasks: tasks, riders: riders, tasks_query: tasks_query, riders_query: riders_query} = assigns
 
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(:tasks_list, filter_tasks(campaign.tasks, tasks_query))
-     |> assign(:riders_list, filter_riders(campaign.riders, riders_query))}
+     |> assign(:tasks_list, filter_tasks(tasks, tasks_query))
+     |> assign(:riders_list, filter_riders(riders, riders_query))}
   end
 
   @impl true
@@ -24,14 +24,14 @@ defmodule BikeBrigadeWeb.CampaignLive.MapComponent do
         class="h-full">
       <leaflet-marker phx-hook="LeafletMarker" id={"task-from-marker:#{@campaign.id}"} data-lat={ lat(@campaign.location) } data-lng={ lng(@campaign.location) }
         data-icon="warehouse" data-color="#1c64f2"></leaflet-marker>
-      <%= for task <- @tasks_list do %>
+      <%= for {_id, task} <- @tasks_list do %>
         <leaflet-marker phx-hook="LeafletMarker" id={"task-to-marker:#{task.id}"}
           data-click-event="select-task" data-click-value-id={ task.id }
           data-lat={ lat(task.dropoff_location) } data-lng={ lng(task.dropoff_location) }
           data-icon={ if task_assigned?(task), do: "circle", else: "cross" } data-color={ cond do selected?(@selected_task, task) -> "#5145cd"; rider_task?(@selected_rider, task) -> "#6875f5"; true -> "#c3ddfd" end}></leaflet-marker>
 
       <% end %>
-      <%= for rider <- @riders_list do %>
+      <%= for {_id, rider} <- @riders_list do %>
         <.live_component module={RiderMarkerComponent} id={rider.id} rider={rider} selected_rider={@selected_rider} selected_task={@selected_task} />
       <% end %>
     </leaflet-map>

--- a/lib/bike_brigade_web/live/campaign_live/messaging_form_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/messaging_form_component.html.heex
@@ -5,8 +5,8 @@
         Preview for rider
       </label>
       <form id="select-rider-form" phx-target={@myself} phx-change="select-rider">
-      <select id="selected_rider_index" name="selected_rider_index" class="block w-full py-2 pl-3 pr-10 mt-1 text-base border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
-        <%= rider_selection_options(@campaign, @selected_rider_index) %>
+      <select id="selected_rider_id" name="selected_rider_id" class="block w-full py-2 pl-3 pr-10 mt-1 text-base border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+        <%= rider_selection_options(@riders, @selected_rider) %>
       </select>
       </form>
     </div>

--- a/lib/bike_brigade_web/live/campaign_live/riders_list_component.ex
+++ b/lib/bike_brigade_web/live/campaign_live/riders_list_component.ex
@@ -6,11 +6,11 @@ defmodule BikeBrigadeWeb.CampaignLive.RidersListComponent do
   import BikeBrigade.Utils, only: [task_count: 1]
 
   def update(assigns, socket) do
-    %{campaign: campaign, riders_query: riders_query} = assigns
+    %{riders: riders, riders_query: riders_query} = assigns
 
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(:riders_list, filter_riders(campaign.riders, riders_query))}
+     |> assign(:riders_list, filter_riders(riders, riders_query))}
   end
 end

--- a/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
@@ -15,7 +15,7 @@
       Riders
     </h3>
     <div class="text-base font-medium leading-6 text-gray-800">
-      <%= Enum.count(@campaign.riders, &rider_available?/1) %> / <%= Enum.count(@campaign.riders) %> available
+      <%= Map.values(@riders) |> Enum.count(&rider_available?/1) %> / <%= Enum.count(@riders) %> available
     </div>
   </div>
   <div class="p-2 border-b">
@@ -32,7 +32,7 @@
       placeholder="Search Riders" />
   </div>
   <ul class="flex-1 overflow-y-auto scrolling-touch" id="riders-list" phx-hook="RidersList">
-    <%= for rider <- @riders_list do %>
+    <%= for {_id, rider} <- @riders_list do %>
       <li id={"riders-list:#{rider.id}"}>
         <a phx-click="select-rider" phx-value-id={rider.id} href="#"
         class={"block transition duration-150 ease-in-out hover:bg-gray-50 focus:outline-none focus:bg-gray-50#{if selected?(@selected_rider, rider), do: " bg-gray-100"}"}>

--- a/lib/bike_brigade_web/live/campaign_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/show.html.heex
@@ -56,6 +56,7 @@
   module={BikeBrigadeWeb.CampaignLive.MessagingFormComponent}
   id={@campaign.id}
   campaign={@campaign}
+  riders={@riders}
   return_to={Routes.campaign_show_path(@socket, :show, @campaign.id)} />
 </UI.slideover>
 
@@ -65,7 +66,7 @@
   <.live_component
     module={BikeBrigadeWeb.SmsMessageLive.FormComponent}
     id={:bulk_message}
-    initial_riders={@campaign.riders}
+    initial_riders={Map.values(@riders)}
     current_user={@current_user}/>
 </UI.modal>
 
@@ -125,14 +126,14 @@
     </div>
   <div class="grid min-h-0 grid-cols-2 gap-4 md:h-full md:grid-cols-4">
     <div class="px-2 py-3 bg-white shadow min-h-96 max-h-128 md:min-h-0 md:max-h-full x-2 md:h-full sm:rounded-lg">
-      <.live_component module={TasksListComponent} id={:tasks_list} campaign={@campaign} tasks_query={@tasks_query} selected_task={@selected_task} selected_rider={@selected_rider} />
+      <.live_component module={TasksListComponent} id={:tasks_list} campaign={@campaign} tasks={@tasks} tasks_query={@tasks_query} selected_task={@selected_task} selected_rider={@selected_rider} />
     </div>
     <div class="px-2 py-3 bg-white shadow min-h-96 max-h-128 md:min-h-0 md:max-h-full md:h-full md:order-last sm:rounded-lg">
-        <.live_component module={RidersListComponent} id={:riders_list} campaign={@campaign} riders_query={@riders_query} selected_task={@selected_task} selected_rider={@selected_rider} resent={@resent}/>
+        <.live_component module={RidersListComponent} id={:riders_list} campaign={@campaign} riders={@riders} riders_query={@riders_query} selected_task={@selected_task} selected_rider={@selected_rider} resent={@resent}/>
     </div>
     <div class="col-span-2 bg-white shadow min-h-96 max-h-128 md:min-h-0 md:max-h-full sm:rounded-lg">
       <div class="px-4 py-5 h-96 md:h-full sm:p-6">
-        <.live_component module={MapComponent} id={:tasks_map} campaign={@campaign} tasks_query={@tasks_query} riders_query={@riders_query} selected_task={@selected_task} selected_rider={@selected_rider} />
+        <.live_component module={MapComponent} id={:tasks_map} campaign={@campaign} tasks={@tasks} riders={@riders} tasks_query={@tasks_query} riders_query={@riders_query} selected_task={@selected_task} selected_rider={@selected_rider} />
       </div>
     </div>
   </div>

--- a/lib/bike_brigade_web/live/campaign_live/tasks_list_component.ex
+++ b/lib/bike_brigade_web/live/campaign_live/tasks_list_component.ex
@@ -8,12 +8,12 @@ defmodule BikeBrigadeWeb.CampaignLive.TasksListComponent do
 
   @impl true
   def update(assigns, socket) do
-    %{campaign: campaign, tasks_query: tasks_query} = assigns
+    %{tasks: tasks, tasks_query: tasks_query} = assigns
 
     {:ok,
      socket
      |> assign(assigns)
-     |> assign(:tasks_list, filter_tasks(campaign.tasks, tasks_query))}
+     |> assign(:tasks_list, filter_tasks(tasks, tasks_query))}
   end
 
   @impl true
@@ -26,7 +26,7 @@ defmodule BikeBrigadeWeb.CampaignLive.TasksListComponent do
     task = Delivery.get_task(task_id)
 
     Delivery.update_task(task, %{
-      delivery_status: delivery_status,
+      delivery_status: delivery_status
     })
 
     {:noreply, socket}

--- a/lib/bike_brigade_web/live/campaign_live/tasks_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/tasks_list_component.html.heex
@@ -10,7 +10,7 @@
       Tasks
     </h3>
     <div class="text-base font-medium leading-6 text-gray-800">
-      <%= Enum.count(@campaign.tasks, &task_assigned?/1) %> / <%= Enum.count(@campaign.tasks) %> assigned
+      <%= Map.values(@tasks) |> Enum.count(&task_assigned?/1) %> / <%= Enum.count(@tasks) %> assigned
     </div>
   </div>
   <div class="p-2 border-b">
@@ -33,7 +33,7 @@
       placeholder="Search Deliveries" />
   </div>
   <ul class="flex-1 overflow-y-auto scrolling-touch" id="tasks-list" phx-hook="TasksList">
-    <%= for task <- @tasks_list do %>
+    <%= for {_id, task} <- @tasks_list do %>
     <li id={"tasks-list:#{task.id}"}>
       <a phx-click="select-task" phx-value-id={task.id} href="#"
         class={"block transition duration-150 ease-in-out hover:bg-gray-50 focus:outline-none focus:bg-gray-50 #{if selected?(@selected_task, task), do: "bg-gray-100", else: ""}"}>

--- a/lib/bike_brigade_web/live/printable_live/campaign_assignments.ex
+++ b/lib/bike_brigade_web/live/printable_live/campaign_assignments.ex
@@ -14,15 +14,16 @@ defmodule BikeBrigadeWeb.PrintableLive.CampaignAssignments do
   @impl true
   def handle_params(%{"id" => id}, _url, socket) do
     campaign = Delivery.get_campaign(id)
+    {_riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
 
     tasks =
-      campaign.tasks
+      tasks
       |> Enum.sort_by(&(&1.assigned_rider && String.downcase(&1.assigned_rider.name)))
 
     {:noreply,
      socket
      |> assign(:campaign_title, name(campaign))
-     |> assign(:campaign_date, campaign.delivery_date)
+     |> assign(:campaign_date, campaign_date(campaign))
      |> assign(:tasks, tasks)}
   end
 end

--- a/lib/bike_brigade_web/live/printable_live/safety_check.ex
+++ b/lib/bike_brigade_web/live/printable_live/safety_check.ex
@@ -14,11 +14,12 @@ defmodule BikeBrigadeWeb.PrintableLive.SafetyCheck do
   @impl true
   def handle_params(%{"id" => id}, _url, socket) do
     campaign = Delivery.get_campaign(id)
+    {riders, _tasks} = Delivery.campaign_riders_and_tasks(campaign)
 
     {:noreply,
      socket
      |> assign(:campaign_title, name(campaign))
-     |> assign(:campaign_date, campaign.delivery_date)
-     |> assign(:riders, campaign.riders)}
+     |> assign(:campaign_date, campaign_date(campaign))
+     |> assign(:riders, riders)}
   end
 end

--- a/lib/bike_brigade_web/live/printable_live/safety_check.html.heex
+++ b/lib/bike_brigade_web/live/printable_live/safety_check.html.heex
@@ -34,7 +34,7 @@
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
           <%= for rider <- @riders do %>
-            <tr id={rider.id} class="leading-tight">
+            <tr id={"rider-#{rider.id}"} class="leading-tight">
               <td class="w-24 px-6 text-xs leading-5 text-gray-500 border">
                 <div class="flex items-center justify-between">
                   <div><%= rider.name %> (<%= rider.pronouns %>)</div>

--- a/lib/bike_brigade_web/live/program_live/form_component.ex
+++ b/lib/bike_brigade_web/live/program_live/form_component.ex
@@ -7,12 +7,14 @@ defmodule BikeBrigadeWeb.ProgramLive.FormComponent do
 
   @impl Phoenix.LiveComponent
   def update(%{program: program} = assigns, socket) do
+    program = BikeBrigade.Repo.preload(program, [:items])
     program_form = ProgramForm.from_program(program)
     changeset = ProgramForm.changeset(program_form)
 
     {:ok,
      socket
      |> assign(assigns)
+     |> assign(:program, program)
      |> assign(:program_form, program_form)
      |> assign(:changeset, changeset)}
   end

--- a/lib/bike_brigade_web/live/program_live/index.ex
+++ b/lib/bike_brigade_web/live/program_live/index.ex
@@ -63,6 +63,6 @@ defmodule BikeBrigadeWeb.ProgramLive.Index do
   end
 
   defp list_programs do
-    Delivery.list_programs()
+    Delivery.list_programs(preload: [:lead, :latest_campaign, :stats])
   end
 end

--- a/lib/bike_brigade_web/live/program_live/index.html.heex
+++ b/lib/bike_brigade_web/live/program_live/index.html.heex
@@ -54,7 +54,7 @@
     <% end %>
   </:td>
   <:td let={program}>
-    <%= program.campaign_count %>
+    <%= program.stats.campaign_count %>
   </:td>
   <:td let={program}>
     <%= if latest_campaign = program.latest_campaign do %>

--- a/lib/bike_brigade_web/live/program_live/show.ex
+++ b/lib/bike_brigade_web/live/program_live/show.ex
@@ -16,7 +16,7 @@ defmodule BikeBrigadeWeb.ProgramLive.Show do
   @spec handle_params(map, any, Phoenix.LiveView.Socket.t()) ::
           {:noreply, Phoenix.LiveView.Socket.t()}
   def handle_params(%{"id" => id}, _, socket) do
-    program = Delivery.get_program!(id)
+    program = Delivery.get_program!(id, preload: [:lead, :items, campaigns: [:stats]])
 
     {:noreply,
      socket

--- a/lib/bike_brigade_web/live/program_live/show.html.heex
+++ b/lib/bike_brigade_web/live/program_live/show.html.heex
@@ -34,10 +34,10 @@
     <div class="w-24 truncate"><%= if campaign.delivery_start, do: time_interval(campaign.delivery_start, campaign.delivery_end), else: campaign.pickup_window %></div>
   </:td>
   <:td let={campaign}>
-    <%= campaign.total_riders %>
+    <%= campaign.stats.rider_count %>
   </:td>
   <:td let={campaign}>
-    <%= campaign.total_tasks %>
+    <%= campaign.stats.task_count %>
   </:td>
   <:td let={campaign} class="text-right">
     <%= live_redirect "Edit", to: Routes.campaign_index_path(@socket, :edit, campaign), class: "text-indigo-600 hover:text-indigo-900" %>

--- a/priv/repo/migrations/20220314170954_campaigns_latest_messages_view.exs
+++ b/priv/repo/migrations/20220314170954_campaigns_latest_messages_view.exs
@@ -1,0 +1,8 @@
+defmodule BikeBrigade.Repo.Migrations.CampaignsLatestMessagesView do
+  use Ecto.Migration
+  import BikeBrigade.MigrationUtils
+
+  def change do
+    load_sql("campaigns_latest_sms_messages_view.sql", "drop view if exists campaigns_latest_sms_messages")
+  end
+end

--- a/priv/repo/migrations/20220314205147_campaign_stats_view.exs
+++ b/priv/repo/migrations/20220314205147_campaign_stats_view.exs
@@ -1,0 +1,8 @@
+defmodule BikeBrigade.Repo.Migrations.CampaignStatsView do
+  use Ecto.Migration
+  import BikeBrigade.MigrationUtils
+
+  def change do
+    load_sql("campaign_stats_view.sql", "drop view if exists campaign_stats")
+  end
+end

--- a/priv/repo/sql/campaign_stats_view.sql
+++ b/priv/repo/sql/campaign_stats_view.sql
@@ -1,0 +1,17 @@
+create
+or replace view campaign_stats as
+select
+  campaigns.program_id as program_id, -- useful if we ever need program stats
+  campaigns.id as campaign_id,
+  count(distinct campaigns.id) as campaign_count, -- useful if we ever need program stats
+  count(tasks.id) as task_count,
+  count(distinct tasks.assigned_rider_id) as rider_count,
+  sum(delivery_distance) as total_distance
+from
+  tasks
+  left join campaigns on campaigns.id = tasks.campaign_id
+where
+  tasks.assigned_rider_id IS NOT NULL
+  and campaigns.delivery_start <= NOW()
+group by
+  ROLLUP(program_id, campaigns.id)

--- a/priv/repo/sql/campaigns_latest_sms_messages_view.sql
+++ b/priv/repo/sql/campaigns_latest_sms_messages_view.sql
@@ -1,0 +1,20 @@
+create
+or replace view campaigns_latest_sms_messages as
+select
+  campaign_id,
+  sms_message_id
+from
+  (
+    select
+      sms_messages.campaign_id as campaign_id,
+      sms_messages.id as sms_message_id,
+      ROW_NUMBER() over (
+        PARTITION BY sms_messages.campaign_id
+        ORDER BY
+          sms_messages.sent_at DESC
+      ) as row_number
+    from
+      sms_messages
+  ) as result
+where
+  row_number = 1;


### PR DESCRIPTION
This is a big-ish refactor that I hope simplifies a lot of the complex queries in `delivery.ex`. The goal here is to make it easier to change queries by trying to make things more composable, and to move the complex associations we have for stats and latest messages into views -- before I was preloading a ton of tasks and riders anytime you called `get_campaign`. Now it's up to the caller to decide what to preload.

I created two new views to use with associations:
- `campaigns_latest_messages` gives you the id of the most recently sent message for the campaign
- `campaign_stats` is stats for campaigns (and programs), giving us total task counts, rider counts, and distance counts

They can be loaded as `Repo.preload(campaign, :stats)`, `Repo.preload(program, :stats)` and `Repo.preload(campaign, :latest_message)`

I refactored the following functions
- `Delivery.get_campaign/1`
- `Delivery.list_campaigns/1
- `Delivery.get_program/1`
- `Delivery.list_programs/0`

These all now take an optional keyword argument that lets you set `preloads` which will automatically preload associations. I preload `program` onto campaigns by default.

There is also a new `Delivery.campaign_get_riders_and_tasks/1` which returns a tuple of riders and tasks -- this was done with a messy preload before.