### PR TITLE
Add text based itineraries

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -389,7 +389,6 @@ defmodule BikeBrigade.Delivery do
   end
 
   def send_campaign_message(%Campaign{} = campaign, rider) do
-    # TODO, split SMS semantically somehow
     body =
       render_campaign_message_for_rider(
         campaign,
@@ -397,29 +396,37 @@ defmodule BikeBrigade.Delivery do
         rider
       )
 
-    if String.length(body) > 1500 do
-      parts =
-        body
-        |> String.codepoints()
-        |> Enum.chunk_every(1000)
-        |> Enum.map(&Enum.join/1)
+    msg = Messaging.send_message_in_chunks(campaign, body, rider)
 
-      [first | rest] = parts
-      msg = Messaging.new_sms_message(rider)
-
-      Messaging.send_sms_message(msg, %{campaign_id: campaign.id, body: first <> "..."})
-
-      for part <- rest do
-        msg = Messaging.new_sms_message(rider)
-        Messaging.send_sms_message(msg, %{campaign_id: campaign.id, body: "..." <> part})
-      end
-    else
-      msg = Messaging.new_sms_message(rider)
-      Messaging.send_sms_message(msg, %{campaign_id: campaign.id, body: body})
+    if rider.text_based_itinerary do
+      send_text_based_itinerary(rider, campaign)
     end
+
+    msg
   end
 
-  # TODO I hate that i pass message here so much
+  defp send_text_based_itinerary(rider, campaign) do
+    template = """
+    1. Pickup
+    • {{{task_count}}}
+    • {{{pickup_address}}}
+    • {{{pickup_window}}}
+
+    2. Drop-off
+    {{{task_details}}}
+
+    {{{directions}}}
+    """
+
+    body =
+      render_campaign_message_for_rider(
+        campaign,
+        template,
+        rider
+      )
+
+    Messaging.send_message_in_chunks(campaign, body, rider)
+  end
 
   def render_campaign_message_for_rider(campaign, nil, rider),
     do: render_campaign_message_for_rider(campaign, "", rider)

--- a/lib/bike_brigade/riders/rider.ex
+++ b/lib/bike_brigade/riders/rider.ex
@@ -61,6 +61,7 @@ defmodule BikeBrigade.Riders.Rider do
     field :onfleet_id, :string
     field :onfleet_account_status, OnfleetAccountStatusEnum
     field :phone, BikeBrigade.EctoPhoneNumber.Canadian
+    field :text_based_itinerary, :boolean, default: false
     # remove
     field :postal, :string
     field :pronouns, :string
@@ -78,6 +79,7 @@ defmodule BikeBrigade.Riders.Rider do
     field :task_enter_building, :boolean, virtual: true
     field :delivery_url_token, :string, virtual: true
     field :pickup_window, :string, virtual: true
+
 
     field :internal_notes, :string
 
@@ -130,7 +132,8 @@ defmodule BikeBrigade.Riders.Rider do
       :mailchimp_id,
       :mailchimp_status,
       :last_safety_check,
-      :internal_notes
+      :internal_notes,
+      :text_based_itinerary
     ])
     |> cast_embed(:flags)
     |> cast_embed(:location_struct)

--- a/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
@@ -3,8 +3,8 @@
     <C.button phx-click="auto-assign" size={:small} class="space-x-1">
       <p>Auto Assign</p>
       <C.tooltip tooltip={"This will assign the remaining tasks"} class="w-40">
-      <Heroicons.Outline.exclamation_circle class="w-4 h-4" />
-    </C.tooltip>
+        <Heroicons.Outline.exclamation_circle class="w-4 h-4" />
+      </C.tooltip>
     </C.button>
     <C.button patch_to={Routes.campaign_show_path(@socket, :add_rider, @campaign)} size={:small}>
       Add Rider
@@ -36,15 +36,20 @@
       <li id={"riders-list:#{rider.id}"}>
         <a phx-click="select-rider" phx-value-id={rider.id} href="#"
         class={"block transition duration-150 ease-in-out hover:bg-gray-50 focus:outline-none focus:bg-gray-50#{if selected?(@selected_rider, rider), do: " bg-gray-100"}"}>
-          <div class="flex flex-row px-4 py-4">
+          <div class="flex flex-row items-center px-4 py-4">
             <div class="text-sm font-medium">
-              <%= rider.name %> <span class="text-xs"> (<%= task_count(rider.assigned_tasks) %> / <%= rider.task_capacity %>)</span>
+              <%= rider.name %> <span class="text-xs">(<%= task_count(rider.assigned_tasks) %> / <%= rider.task_capacity %>)</span>
             </div>
             <%= if rider.task_enter_building do %>
               <Heroicons.Outline.office_building class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500 justify-self-end" />
             <% end %>
             <%= if has_notes?(rider) do %>
-              <Heroicons.Outline.pencil_alt class="flex-shrink-0 w-4 h-4 text-gray-500" />
+              <Heroicons.Outline.pencil_alt class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500" />
+            <% end %>
+            <%= if rider.text_based_itinerary do %>
+              <C.tooltip tooltip={"This rider will receive an extra message with text-only delivery instructions"} class="w-40">
+                <Heroicons.Outline.status_offline class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500" />
+              </C.tooltip>
             <% end %>
           </div>
         </a>

--- a/lib/bike_brigade_web/live/rider_live/form_component.ex
+++ b/lib/bike_brigade_web/live/rider_live/form_component.ex
@@ -22,6 +22,7 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
       field :max_distance, :integer
       field :last_safety_check, :date
       field :internal_notes, :string
+      field :text_based_itinerary, :boolean
       field :tags, {:array, :string}
 
       embeds_one :flags, Rider.Flags, on_replace: :update
@@ -39,6 +40,7 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
         :max_distance,
         :last_safety_check,
         :internal_notes,
+        :text_based_itinerary,
         :tags
       ])
       |> cast_embed(:flags)

--- a/lib/bike_brigade_web/live/rider_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/rider_live/form_component.html.heex
@@ -99,6 +99,14 @@
       </div>
       <%= error_tag f, :last_safety_check %>
     </div>
+    <div class="flex items-center mt-4 space-x-2">
+      <div class="rounded-md shadow-sm">
+        <%= checkbox f, :text_based_itinerary, phx_debounce: "blur", class: "w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500" %>
+      </div>
+      <%= label f, :text_based_itinerary, class: "block text-sm font-medium leading-5 text-gray-700" do %>
+      Send text-only delivery instructions
+      <% end %>
+    </div>
     <div class="pt-8">
       <div>
         <h3 class="text-lg font-medium leading-6 text-gray-900">

--- a/lib/bike_brigade_web/live/rider_live/show.html.heex
+++ b/lib/bike_brigade_web/live/rider_live/show.html.heex
@@ -50,6 +50,12 @@
                     <Heroicons.Outline.briefcase aria-label="Briefcase" class="inline-flex flex-shrink-0 w-5 h-5 text-gray-400 sm:mr-.5" />
                     <%= live_redirect @rider.capacity, to: Routes.rider_index_path(@socket, :index, %{capacity: [@rider.capacity]}), class: "link" %>
                 </span>
+                <%= if @rider.text_based_itinerary do %>
+                    <span class="">
+                        <Heroicons.Outline.status_offline aria-label="Status Offline" class="inline-flex flex-shrink-0 w-5 h-5 text-gray-400 sm:mr-.5" />
+                        Text-only delivery instructions
+                    </span>
+                <% end %>
                 <span class="block xl:inline">
                     <Heroicons.Outline.tag aria-label="Tag" class="inline-flex flex-shrink-0 w-5 h-5 text-gray-400 xl:ml-2 sm:mr-.5" />
                     <%= if Enum.empty?(@rider.tags) do %>

--- a/priv/repo/migrations/20220330153357_add_text_based_itinerary_to_riders_table.exs
+++ b/priv/repo/migrations/20220330153357_add_text_based_itinerary_to_riders_table.exs
@@ -1,0 +1,9 @@
+defmodule BikeBrigade.Repo.Migrations.AddTextBasedItineraryToRidersTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:riders) do
+      add :text_based_itinerary, :boolean, default: false, null: false
+    end
+  end
+end


### PR DESCRIPTION
For riders that do not have a smartphone, or do not have data capabilities, provide a way for them to receive text-only instructions as a follow-up message.

<img width="298" alt="image" src="https://user-images.githubusercontent.com/8824824/160903369-b755bc68-819a-414c-88ec-76560b03dc50.png">

<img width="590" alt="image" src="https://user-images.githubusercontent.com/8824824/160903570-3b3746a7-6fad-4485-b051-a3a847f5352d.png">
