### PR TITLE
Require program ID to create campaign

### DIFF
--- a/lib/bike_brigade/delivery/campaign.ex
+++ b/lib/bike_brigade/delivery/campaign.ex
@@ -75,7 +75,7 @@ defmodule BikeBrigade.Delivery.Campaign do
     |> cast_assoc(:riders, required: false)
     |> cast_assoc(:instructions_template, required: false)
     |> cast_assoc(:scheduled_message, required: false)
-    |> validate_required([:delivery_start, :delivery_end, :location])
+    |> validate_required([:delivery_start, :delivery_end, :location, :program_id])
     # TODO is this actually unique
     |> unique_constraint(:name)
   end


### PR DESCRIPTION
Campaigns are created as part of an existing program (that they belong to).

Otherwise—in the case of an orphaned campaign—we [try to access its name](https://github.com/bikebrigade/dispatch/blob/eb622fe4f6dab7c917d678d3d7a322a01f97da44/lib/bike_brigade_web/views/campaign_helpers.ex#L98-L106) instead of the name of the program it should otherwise belong to, resulting in a `KeyError`:
 
> key :name not found in: %BikeBrigade.Delivery.Campaign{…}