### PR TITLE
Add twilio sid/status as hover text in messaging

### DIFF
--- a/lib/bike_brigade_web/live/sms_message_live/conversation_component.html.heex
+++ b/lib/bike_brigade_web/live/sms_message_live/conversation_component.html.heex
@@ -26,7 +26,12 @@
           <%= if @rider do %>
             <div class="flex flex-col">
               <div class="pii">
-                <span><%= live_redirect @rider.name, to: Routes.rider_show_path(@socket, :show, @rider), class: "link" %></span>
+                <span>
+                  <%= live_redirect(@rider.name,
+                    to: Routes.rider_show_path(@socket, :show, @rider),
+                    class: "link"
+                  ) %>
+                </span>
                 <span class="ml-1 text-sm text-gray-500">
                   (<%= if @rider.pronouns, do: @rider.pronouns, else: "pronouns unknown" %>)
                 </span>
@@ -131,15 +136,25 @@
                   <div class="text-xs text-gray-600">
                     <%= case message.twilio_status do %>
                       <% "queued" -> %>
-                        <Heroicons.Solid.dots_horizontal class="w-4 h-4" />
+                        <C.tooltip tooltip="Queued">
+                          <Heroicons.Solid.dots_horizontal class="w-4 h-4" />
+                        </C.tooltip>
                       <% "sent" -> %>
-                        <Heroicons.Solid.arrow_circle_right class="w-4 h-4" />
+                        <C.tooltip tooltip="Sent">
+                          <Heroicons.Solid.arrow_circle_right class="w-4 h-4" />
+                        </C.tooltip>
                       <% "delivered" -> %>
-                        <Heroicons.Solid.check_circle class="w-4 h-4" />
+                        <C.tooltip tooltip="Delivered">
+                          <Heroicons.Solid.check_circle class="w-4 h-4" />
+                        </C.tooltip>
                       <% "undelivered" -> %>
-                        <Heroicons.Solid.exclamation_circle class="text-red-600 w-4 h-4" />
+                        <C.tooltip tooltip="Undelivered">
+                          <Heroicons.Solid.exclamation_circle class="w-4 h-4 text-red-600" />
+                        </C.tooltip>
                       <% "failed" -> %>
-                        <Heroicons.Solid.exclamation_circle class="text-red-600 w-4 h-4" />
+                        <C.tooltip tooltip="Failed">
+                          <Heroicons.Solid.exclamation_circle class="w-4 h-4 text-red-600" />
+                        </C.tooltip>
                       <% _ -> %>
                     <% end %>
                   </div>

--- a/lib/bike_brigade_web/live/sms_message_live/conversation_component.html.heex
+++ b/lib/bike_brigade_web/live/sms_message_live/conversation_component.html.heex
@@ -117,7 +117,11 @@
                 <span class="whitespace-pre-wrap"><%= render_raw(message.body) %></span>
               </div>
               <div class="px-1 my-0.5 flex justify-between">
-                <div class="text-xs font-bold"><%= datetime(message.sent_at) %></div>
+                <div class="text-xs font-bold">
+                  <C.tooltip tooltip={"Twilio SID: #{message.twilio_sid}"}>
+                    <%= datetime(message.sent_at) %>
+                  </C.tooltip>
+                </div>
                 <div class="flex flex-row space-x-1">
                   <%= cond do %>
                     <% message.campaign_id -> %>


### PR DESCRIPTION
Closes #142
<img width="453" alt="Screen Shot 2022-07-06 at 6 42 37 PM" src="https://user-images.githubusercontent.com/34720/177655286-3e45c12f-efce-4831-99d6-d088f6cb051d.png">
and 

<img width="567" alt="Screen Shot 2022-07-06 at 6 42 30 PM" src="https://user-images.githubusercontent.com/34720/177655287-c9f5f5c4-3bd3-4509-845a-715dfb40c24f.png">

