### PR TITLE
Fix bug with local storage adapter and make adapter config happen at runtime

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -146,8 +146,8 @@ case System.get_env("GOOGLE_SERVICE_JSON") do
 
   _no_json ->
     config :bike_brigade, :media_storage,
-      adapter: BikeBrigade.MediaStorage.FakeMediaStorage,
-      bucket: System.get_env("GOOGLE_STORAGE_BUCKET", "bike-brigade-fake")
+      adapter: BikeBrigade.MediaStorage.LocalMediaStorage,
+      bucket: "bike-brigade-media"
 end
 
 case System.get_env("MAILCHIMP_API_KEY") do

--- a/lib/bike_brigade/adapter.ex
+++ b/lib/bike_brigade/adapter.ex
@@ -1,16 +1,12 @@
 defmodule BikeBrigade.Adapter do
   defmacro __using__(cfg_section) do
-    {module, args} =
-      BikeBrigade.Utils.fetch_env!(cfg_section, :adapter)
-      |> extract_module_and_args()
-
     quote do
-      # Generate a module attribute that exposes the module
-      Module.put_attribute(
-        __MODULE__,
-        unquote(cfg_section),
-        unquote(module)
-      )
+      @doc """
+      Expose the dynamically configured adapter
+      """
+      def adapter() do
+        BikeBrigade.Adapter.Utils.extract_adapter(unquote(cfg_section))
+      end
 
       @doc """
       Add a child spec to `children` if the adapter
@@ -18,24 +14,30 @@ defmodule BikeBrigade.Adapter do
       """
       @spec append_child_spec(list) :: list
       def append_child_spec(children) when is_list(children) do
-        module = unquote(module)
-        args = unquote(args)
+        module = BikeBrigade.Adapter.Utils.extract_adapter(unquote(cfg_section))
+        args = BikeBrigade.Adapter.Utils.extract_adapter_args(unquote(cfg_section))
 
         case Kernel.function_exported?(module, :start_link, 1) do
           true -> children ++ [{module, args}]
           false -> children
         end
       end
-
-      @doc """
-      Expose the dynamically configured adapter
-      """
-      def adapter(), do: unquote(module)
     end
   end
 
-  defp extract_module_and_args(module) when is_atom(module), do: {module, []}
+  defmodule Utils do
+    def extract_adapter(cfg_section) do
+      case BikeBrigade.Utils.fetch_env!(cfg_section, :adapter) do
+        module when is_atom(module) -> module
+        {module, _} when is_atom(module) -> module
+      end
+    end
 
-  defp extract_module_and_args({module, args}) when is_atom(module) and is_list(args),
-    do: {module, args}
+    def extract_adapter_args(cfg_section) do
+      case BikeBrigade.Utils.fetch_env!(cfg_section, :adapter) do
+        module when is_atom(module) -> []
+        {module, args} when is_atom(module) and is_list(args) -> args
+      end
+    end
+  end
 end

--- a/lib/bike_brigade/geocoder.ex
+++ b/lib/bike_brigade/geocoder.ex
@@ -12,7 +12,7 @@ defmodule BikeBrigade.Geocoder do
   def lookup(search, opts \\ [])
 
   def lookup(search, opts) when is_binary(search) do
-    module = Keyword.get(opts, :module, @geocoder)
+    module = Keyword.get(opts, :module, adapter())
     pid = Keyword.get(opts, :pid, module)
 
     module.lookup(pid, search)

--- a/lib/bike_brigade/mailchimp_api.ex
+++ b/lib/bike_brigade/mailchimp_api.ex
@@ -13,10 +13,10 @@ defmodule BikeBrigade.MailchimpApi do
   @doc """
   Get mailing list's members
   """
-  def get_list(list_id, opted_in \\ nil), do: @mailchimp.get_list(list_id, opted_in)
+  def get_list(list_id, opted_in \\ nil), do: adapter().get_list(list_id, opted_in)
 
   @doc """
   Update merge fields for a member
   """
-  def update_member_fields(list_id, email, fields), do: @mailchimp.update_member_fields(list_id, email, fields)
+  def update_member_fields(list_id, email, fields), do: adapter().update_member_fields(list_id, email, fields)
 end

--- a/lib/bike_brigade/media_storage.ex
+++ b/lib/bike_brigade/media_storage.ex
@@ -18,7 +18,7 @@ defmodule BikeBrigade.MediaStorage do
   @spec upload_file(path, content_type) :: success | error
   @spec upload_file(path, content_type, bucket) :: success | error
   def upload_file(path, content_type, bucket \\ find_bucket()) do
-    case @media_storage.upload_file(path, content_type, bucket) do
+    case adapter().upload_file(path, content_type, bucket) do
       {:ok, %{url: _, content_type: _} = response} ->
         {:ok, response}
 
@@ -30,7 +30,8 @@ defmodule BikeBrigade.MediaStorage do
   @spec upload_file!(path, content_type) :: response
   @spec upload_file!(path, content_type, bucket) :: response
   def upload_file!(path, content_type, bucket \\ find_bucket()) do
-    case @media_storage.upload_file(path, content_type, bucket) do
+    case adapter().upload_file(path, content_type, bucket) do
+
       {:ok, %{url: _, content_type: _} = response} ->
         response
 

--- a/lib/bike_brigade/slack_api.ex
+++ b/lib/bike_brigade/slack_api.ex
@@ -23,7 +23,7 @@ defmodule BikeBrigade.SlackApi do
 
   def post_message!(body) do
     headers = [auth_header() | @headers]
-    @slack.post!(@url, body, headers)
+    adapter().post!(@url, body, headers)
   end
 
   defp auth_header() do

--- a/lib/bike_brigade/sms_service.ex
+++ b/lib/bike_brigade/sms_service.ex
@@ -30,7 +30,7 @@ defmodule BikeBrigade.SmsService do
   end
 
   def send_sms(message, opts) when is_list(message) do
-    sms_service = Keyword.get(opts, :sms_service, @sms_service)
+    sms_service = Keyword.get(opts, :sms_service, adapter())
 
     payload =
       case Keyword.get(opts, :send_callback, false) do
@@ -64,7 +64,7 @@ defmodule BikeBrigade.SmsService do
   end
 
   def request_valid?(url, params, signature) do
-    @sms_service.request_valid?(url, params, signature)
+    adapter().request_valid?(url, params, signature)
   end
 
   def sending_confirmation_message() do

--- a/lib/bike_brigade_web/live/campaign_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_live/index.ex
@@ -83,6 +83,7 @@ defmodule BikeBrigadeWeb.CampaignLive.Index do
   end
 
   defp apply_action(socket, :index, _params) do
+    IO.inspect(_params)
     socket
     |> assign(:campaign, nil)
   end

--- a/lib/bike_brigade_web/live/sms_message_live/conversation_component.ex
+++ b/lib/bike_brigade_web/live/sms_message_live/conversation_component.ex
@@ -81,6 +81,7 @@ defmodule BikeBrigadeWeb.SmsMessageLive.ConversationComponent do
         # TODO do some guards on content type here
         MediaStorage.upload_file!(path, content_type)
       end)
+      |> IO.inspect()
 
     {:noreply, send_sms_message(socket, Map.put(sms_message_params, "media", media))}
   end


### PR DESCRIPTION
This PR does two things

1) If you don't have any google config we use the local storage adapter instead of the Fake adapter for media storage - this lets us upload photos to send when testing in dev mode
2) The adapter configs use module variables which get set at compile time. This caused my env to enter a weird state because when I changed the dev.ex, media_storage.ex wasn't recompiled... I followed the guidelines in https://hexdocs.pm/elixir/1.13/library-guidelines.html#avoid-compile-time-application-configuration to switch to using a function so we can set the adapter at runtime