### PR TITLE
Fix login test

### DIFF
--- a/test/bike_brigade_web/features/login_test.exs
+++ b/test/bike_brigade_web/features/login_test.exs
@@ -12,9 +12,9 @@ defmodule BikeBrigadeWeb.Features.LoginTest do
 
     session
     |> visit("/login")
-    |> assert_has(css("h2", text: "Sign in to your account"))
+    |> assert_has(css("h2", text: "Sign into your Bike Brigade account"))
     |> fill_in(text_field("Phone number"), with: user.phone)
-    |> click(button("Get Code"))
+    |> click(button("Get Login Code"))
     |> assert_has(
       css("*[role=notice]", text: "We sent an authentication code to your phone number")
     )


### PR DESCRIPTION
I didn't notice this when I approved @chadmohr's PR #148 -- we had some tests that relied on the exact wording of the login page to test logging in.

This should fix it.