### PR TITLE
Fix: dotenv works when running mix test locally

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,7 +7,10 @@ case config_env() do
       config :bike_brigade, BikeBrigade.Repo, hostname: "postgres"
     end
 
-  DotenvParser.load_file(".env.local")
+    DotenvParser.load_file(".env.local")
+
+  :test ->
+    DotenvParser.load_file(".env.local")
 
   :prod ->
     app_env =


### PR DESCRIPTION
As in #204, we also need to load environment variables for running tests.