### PR TITLE
Add defaults for key env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,3 @@ jobs:
       run: mix assets.deploy
     - name: Run tests
       run: mix test
-    env:
-      GOOGLE_MAPS_API_KEY: ""
-      GOOGLE_SERVICE_JSON: "{}"
-      MAILCHIMP_API_KEY: ""
-      PHONE_NUMBER: "647-555-5555"
-      NEW_PHONE_NUMBER: "647-555-5555"

--- a/config/config.exs
+++ b/config/config.exs
@@ -80,7 +80,7 @@ config :bike_brigade, BikeBrigade.Messaging,
 config :bike_brigade, BikeBrigade.AuthenticationMessenger, phone_number: {:system, "PHONE_NUMBER", default: "647-555-5555"}
 
 # Config our google clients
-config :bike_brigade, BikeBrigade.GoogleMaps, api_key: {:system, "GOOGLE_MAPS_API_KEY"}
+config :bike_brigade, BikeBrigade.GoogleMaps, api_key: {:system, "GOOGLE_MAPS_API_KEY", default: ""}
 
 # Set slack channel IDs for messaging
 config :bike_brigade, BikeBrigade.Messaging.Slack.Operations,

--- a/config/config.exs
+++ b/config/config.exs
@@ -73,11 +73,11 @@ config :bike_brigade, BikeBrigade.Tasks.MailchimpImporter,
 
 # We use the same phone number for our authentication and regular messaging by they are configurable separately for now
 config :bike_brigade, BikeBrigade.Messaging,
-  outbound_number: {:system, "PHONE_NUMBER"},
-  new_outbound_number: {:system, "NEW_PHONE_NUMBER"},
-  inbound_numbers: {:system, "INBOUND_NUMBERS", :optional}
+  outbound_number: {:system, "PHONE_NUMBER", default: "647-555-5555"},
+  new_outbound_number: {:system, "NEW_PHONE_NUMBER", default: "647-555-5555"},
+  inbound_numbers: {:system, "INBOUND_NUMBERS", default: "647-555-5555"}
 
-config :bike_brigade, BikeBrigade.AuthenticationMessenger, phone_number: {:system, "PHONE_NUMBER"}
+config :bike_brigade, BikeBrigade.AuthenticationMessenger, phone_number: {:system, "PHONE_NUMBER", default: "647-555-5555"}
 
 # Config our google clients
 config :bike_brigade, BikeBrigade.GoogleMaps, api_key: {:system, "GOOGLE_MAPS_API_KEY"}

--- a/lib/bike_brigade/utils.ex
+++ b/lib/bike_brigade/utils.ex
@@ -16,7 +16,7 @@ defmodule BikeBrigade.Utils do
       config = Application.get_env(:bike_brigade, __MODULE__)
 
       case config[unquote(keyword)] do
-        {:system, var, :optional} -> System.get_env(var)
+        {:system, var, [default: default]} -> System.get_env(var) || default
         {:system, var} -> System.get_env(var) || raise "Missing environment variable #{var}"
         val when not is_nil(val) -> val
         nil -> raise "Missing configuration: :bike_brigade, #{__MODULE__}, :#{unquote(keyword)}"


### PR DESCRIPTION
This lets us run tests without loading env vars in a file / in CI.