### PR TITLE
Fix: enable opt out of slideover phx-click-away

### DIFF
--- a/lib/bike_brigade_web/core_components.ex
+++ b/lib/bike_brigade_web/core_components.ex
@@ -803,6 +803,7 @@ defmodule BikeBrigadeWeb.CoreComponents do
   attr :wide, :boolean, default: false
   attr :on_cancel, JS, default: %JS{}
   attr :on_confirm, JS, default: %JS{}
+  attr :disable_clickaway, :boolean, default: false
 
   slot :inner_block, required: true
   slot :title
@@ -851,7 +852,7 @@ defmodule BikeBrigadeWeb.CoreComponents do
                 phx-mounted={@show && show_slideover(@id)}
                 phx-window-keydown={hide_slideover(@on_cancel, @id)}
                 phx-key="escape"
-                phx-click-away={hide_slideover(@on_cancel, @id)}
+                phx-click-away={unless @disable_clickaway, do: hide_slideover(@on_cancel, @id)}
                 class="flex flex-col h-full overflow-y-scroll bg-white shadow-xl"
               >
                 <div class="flex-1">

--- a/lib/bike_brigade_web/live/campaign_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/show.html.heex
@@ -203,6 +203,7 @@
   id="messaging"
   show
   wide
+  disable_clickaway={true}
   on_cancel={JS.patch(~p"/campaigns/#{@campaign}")}
 >
   <:title>


### PR DESCRIPTION
Bug replication:
- visit: http://localhost:4000/campaigns/<id>/messaging
- try and insert an emoji
- the slideover closes

This is a quick fix that allows you to disable the click-away for a slideover via an attribute. Not the best solution, but the user can still press the "X" to exit.
