### PR TITLE
Add more directives to messaging

### DIFF
--- a/lib/bike_brigade_web/live/campaign_live/messaging_form_component.ex
+++ b/lib/bike_brigade_web/live/campaign_live/messaging_form_component.ex
@@ -146,10 +146,6 @@ defmodule BikeBrigadeWeb.CampaignLive.MessagingFormComponent do
     end
   end
 
-  defp directives do
-    ~w(rider_name pickup_address pickup_window task_details task_count directions delivery_details_url)
-  end
-
   defp preview(campaign, changeset, selected_rider) do
     body = Ecto.Changeset.get_field(changeset, :instructions_template).body
 

--- a/lib/bike_brigade_web/live/campaign_live/messaging_form_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/messaging_form_component.html.heex
@@ -63,7 +63,7 @@
             type="textarea"
             field={{instructions_template_form, :body}}
             phx-hook="Autocomplete"
-            data-autocomplete={inspect(directives())}
+            data-autocomplete={inspect(Delivery.campaign_message_directives())}
             extra_class="h-80"
           />
         </div>
@@ -79,7 +79,10 @@
     </div>
     <p class="mt-3 text-xs">
       Available directives are:
-      <span :for={directive <- directives()} class="mr-1 font-serif bg-gray-100">
+      <span
+        :for={directive <- Delivery.campaign_message_directives()}
+        class="mr-1 font-serif bg-gray-100"
+      >
         {{{<%= directive %>}}}
       </span>
     </p>

--- a/lib/bike_brigade_web/live/live_helpers.ex
+++ b/lib/bike_brigade_web/live/live_helpers.ex
@@ -31,6 +31,7 @@ defmodule BikeBrigadeWeb.LiveHelpers do
     |> Calendar.strftime("%x %-I:%M%p %Z")
   end
 
+  # TODO: move this!
   def time_interval(start_datetime, end_datetime) do
     if start_datetime == end_datetime do
       LocalizedDateTime.localize(start_datetime)

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -1,0 +1,71 @@
+defmodule BikeBrigade.DeliveryTest do
+  use BikeBrigade.DataCase
+
+  alias BikeBrigade.{LocalizedDateTime, Delivery, Delivery.Task}
+
+  use Phoenix.VerifiedRoutes, endpoint: BikeBrigadeWeb.Endpoint, router: BikeBrigadeWeb.Router
+
+  describe "Campaign Messaging" do
+    setup do
+      program = fixture(:program, %{name: "ACME Delivery"})
+
+      campaign =
+        fixture(:campaign, %{
+          program_id: program.id,
+          delivery_start: LocalizedDateTime.localize(~N[2023-01-01 10:00:00]),
+          delivery_end: LocalizedDateTime.localize(~N[2023-01-01 11:00:00])
+        })
+
+      rider = fixture(:rider, %{name: "Hannah Bannana"})
+      task = fixture(:task, %{campaign: campaign, rider: rider})
+
+      %{campaign: campaign, rider: rider, task: task}
+    end
+
+    test "render_campaign_message_for_rider/3", %{campaign: campaign} do
+      {[rider], [task]} = Delivery.campaign_riders_and_tasks(campaign)
+
+      message = """
+      Hello Hannah,
+      Thanks for signing up for X at {{{pickup_address}}} at {{{pickup_window}}}.  You'll be delivering {{{task_count}}}
+
+      Here is your delivery link: {{{delivery_details_url}}}
+
+      Also here are the details:
+
+      {{{task_details}}}
+
+      Directions: {{{directions}}}
+      """
+
+      directions_url =
+        "https://www.google.com/maps/dir/?api=1&destination=#{to_uri(task.dropoff_location)}&origin=#{to_uri(rider.location)}&travelmode=bicycling&waypoints=#{to_uri(campaign.location)}"
+
+      assert Delivery.render_campaign_message_for_rider(campaign, message, rider) =~
+               """
+               Hello #{BikeBrigade.Riders.Helpers.first_name(rider)},
+               Thanks for signing up for X at #{task.pickup_location} at 10:00-11:00AM.  You'll be delivering 1 #{item_name(task)}
+
+               Here is your delivery link: #{url(~p"/app/delivery/#{rider.delivery_url_token}")}
+
+               Also here are the details:
+
+               Name: #{task.dropoff_name}
+               Phone: #{task.dropoff_phone}
+               Type: 1 #{item_name(task)}
+               Address: #{task.dropoff_location}
+               Notes: #{task.rider_notes}
+
+               Directions: #{directions_url}
+               """
+    end
+  end
+
+  def item_name(%Task{task_items: [%{item: %{name: item_name}}]}), do: item_name
+
+  defp to_uri(location) do
+    location
+    |> String.Chars.to_string()
+    |> URI.encode_www_form()
+  end
+end

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -27,7 +27,7 @@ defmodule BikeBrigade.DeliveryTest do
 
       message = """
       Hello Hannah,
-      Thanks for signing up for X at {{{pickup_address}}} at {{{pickup_window}}}.  You'll be delivering {{{task_count}}}
+      Thanks for signing up for {{program_name}} at {{{pickup_address}}} on {{{delivery_date}}} at {{{pickup_window}}}.  You'll be delivering {{{task_count}}}
 
       Here is your delivery link: {{{delivery_details_url}}}
 
@@ -41,10 +41,10 @@ defmodule BikeBrigade.DeliveryTest do
       directions_url =
         "https://www.google.com/maps/dir/?api=1&destination=#{to_uri(task.dropoff_location)}&origin=#{to_uri(rider.location)}&travelmode=bicycling&waypoints=#{to_uri(campaign.location)}"
 
-      assert Delivery.render_campaign_message_for_rider(campaign, message, rider) =~
+      assert Delivery.render_campaign_message_for_rider(campaign, message, rider) ==
                """
                Hello #{BikeBrigade.Riders.Helpers.first_name(rider)},
-               Thanks for signing up for X at #{task.pickup_location} at 10:00-11:00AM.  You'll be delivering 1 #{item_name(task)}
+               Thanks for signing up for ACME Delivery at #{task.pickup_location} on Sun Jan 1st at 10:00-11:00AM.  You'll be delivering 1 #{item_name(task)}
 
                Here is your delivery link: #{url(~p"/app/delivery/#{rider.delivery_url_token}")}
 


### PR DESCRIPTION
This adds `{{{delivery_date}}}` and `{{{program_name}}}` as possible directives when messaging riders
<img width="814" alt="Screen Shot 2023-02-08 at 2 08 52 PM" src="https://user-images.githubusercontent.com/34720/217640607-0d4c3fbc-08be-4c2d-aa26-00a8ca35dfc1.png">

Plus I added some tests :)

Closes https://github.com/bikebrigade/dispatch/issues/232