### PR TITLE
Fix: make sure we can remove tags.

### DIFF
--- a/lib/bike_brigade_web/live/rider_live/form_component.ex
+++ b/lib/bike_brigade_web/live/rider_live/form_component.ex
@@ -128,6 +128,7 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
   end
 
   defp save_rider(socket, :edit, rider_form_params) do
+    rider_form_params = Map.merge(%{"tags" => []}, rider_form_params)
     with {:ok, form} <-
            RiderForm.update_form(socket.assigns.form, rider_form_params),
          params = RiderForm.to_params(form),

--- a/test/bike_brigade/riders_test.exs
+++ b/test/bike_brigade/riders_test.exs
@@ -37,6 +37,19 @@ defmodule BikeBrigade.RidersTest do
       assert is_nil(Repo.get(Location, location_id))
     end
 
+    test "can add and remove tags", %{rider: rider} do
+      assert Ecto.assoc_loaded?(rider.tags) == false
+      rider = rider |> Repo.preload(:tags)
+      assert rider.tags == []
+
+      {:ok, rider} = rider |> Riders.update_rider_with_tags(%{}, ["tag1", "tag2"])
+      assert Enum.count(rider.tags) == 2
+
+
+      {:ok, rider} = rider |> Riders.update_rider_with_tags(%{}, [])
+      assert Enum.count(rider.tags) == 0
+    end
+
     test "deletes associated tags", %{rider: rider} do
       rider
       |> Repo.preload(:tags)


### PR DESCRIPTION
In response to this [bug report](https://torontobikebrigade.slack.com/archives/C016VGHETS4/p1685498283175119).

The problem: when we remove all tags, the live component that handles the tag state doesn't get included in the form_params going into the live_view — even if it's just an empty list.

Hacky fix: use a map merge to make sure we at least have a default empty list for maps.

I feel that there is probably a better solution, but I'm a little fuzzy on how to work with live components that have child state (as in, how should I get that empty list that would [be here](https://github.com/bikebrigade/dispatch/blob/191f1accb69b2c3eabee5357ae4842a043fb6a49/lib/bike_brigade_web/live/rider_live/tags_component.ex#L36-L40) into the parent form?

Also, I added a test in the process of using TDD to try and fix this / figure out what was wrong. It's not really related, but `¯\_(ツ)_/¯`.

Here's a before and after:

https://github.com/bikebrigade/dispatch/assets/12987958/971001c4-aa8a-4b17-b851-6fb63e37d713


