### PR TITLE
[241] stats polish

### DIFF
--- a/lib/bike_brigade_web/live/rider_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/rider_live/form_component.html.heex
@@ -35,7 +35,7 @@
       />
     </div>
 
-    <div phx-feedback-for={input_name(f, :tags)}>
+    <div :if={@current_user.is_dispatcher} phx-feedback-for={input_name(f, :tags)}>
       <CoreComponents.label for={input_id(f, :tags)}>Tags</CoreComponents.label>
 
       <.live_component
@@ -62,6 +62,7 @@
 
     <.input
       type="textarea"
+      :if={@current_user.is_dispatcher}
       field={{f, :internal_notes}}
       label="Notes (internal)"
       help_text="These are for Bike Brigade dispatchers, and not shared with riders"
@@ -70,6 +71,7 @@
     <.input type="text" field={{f, :max_distance}} label="Max Distance" />
 
     <.input
+      :if={@current_user.is_dispatcher}
       type="date"
       field={{f, :last_safety_check}}
       label="Last Safety Check"
@@ -77,12 +79,13 @@
     />
 
     <.input
+      :if={@current_user.is_dispatcher}
       type="checkbox"
       field={{f, :text_based_itinerary}}
       label="Send text-only delivery instructions"
       help_text="Enable this for riders without smartphones or data plans and they'll get a second message with instructions after you send the link."
     />
-    <div>
+    <div :if={@current_user.is_dispatcher}>
       <div>
         <h3 class="text-lg font-medium leading-6 text-gray-900">
           Flags

--- a/lib/bike_brigade_web/live/rider_live/show.html.heex
+++ b/lib/bike_brigade_web/live/rider_live/show.html.heex
@@ -68,7 +68,7 @@
           <.link href={"mailto:#{email(@rider)}"} class="link"><%= email(@rider) %></.link>
         </span>
       </p>
-      <p class="text-sm !leading-relaxed xl:text-base">
+      <p :if={@current_user.is_dispatcher} class="text-sm !leading-relaxed xl:text-base">
         <span class="">
           <Heroicons.briefcase
             mini
@@ -290,6 +290,7 @@
     id={@rider.id}
     action={@live_action}
     rider={@rider}
+    current_user={@current_user}
     navigate={if @live_action == :edit, do: ~p"/riders/#{@rider}", else: ~p"/profile"}
   />
   <:confirm form="rider-form" type="submit" phx-disable-with="Saving...">Save</:confirm>

--- a/lib/bike_brigade_web/live/rider_live/show.html.heex
+++ b/lib/bike_brigade_web/live/rider_live/show.html.heex
@@ -68,7 +68,9 @@
           <.link href={"mailto:#{email(@rider)}"} class="link"><%= email(@rider) %></.link>
         </span>
       </p>
-      <p :if={@current_user.is_dispatcher} class="text-sm !leading-relaxed xl:text-base">
+      <p :if={@current_user.is_dispatcher}
+         data-testid="dispatch-data-tags-and-capacity"
+         class="text-sm !leading-relaxed xl:text-base">
         <span class="">
           <Heroicons.briefcase
             mini

--- a/test/bike_brigade_web/live/rider_live_test.exs
+++ b/test/bike_brigade_web/live/rider_live_test.exs
@@ -60,7 +60,28 @@ defmodule BikeBrigadeWeb.RiderLiveTest do
     end
   end
 
-  describe "Show" do
+  describe "Show: rider logged-in" do
+    setup [:create_rider, :login_as_rider]
+
+    test "Logged in rider cannot see their tag or capacity", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/profile")
+      refute html =~ "dispatch-data-tags-and-capacity"
+    end
+  end
+
+  describe "Edit: rider logged-in" do
+    setup [:create_rider, :login_as_rider]
+
+    test "Logged in rider cannot dispatch specific fields in slideover", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/profile/edit")
+      refute html =~ "Send text-only delivery instructions"
+      refute html =~ "Flags"
+      refute html =~ "Last Safety Check"
+      refute html =~ "Notes (internal)"
+    end
+  end
+
+  describe "Show: Dispatch logged-in" do
     setup [:create_rider, :login]
 
     test "shows rider", %{conn: conn, rider: rider} do
@@ -68,7 +89,9 @@ defmodule BikeBrigadeWeb.RiderLiveTest do
 
       assert html =~ rider.name
       assert html =~ rider.location.address
+      assert html =~ "dispatch-data-tags-and-capacity"
     end
+
 
     test "edit rider", %{conn: conn, rider: rider} do
       {:ok, view, _html} = live(conn, ~p"/riders/#{rider}/show/edit")
@@ -79,6 +102,14 @@ defmodule BikeBrigadeWeb.RiderLiveTest do
 
       flash = assert_redirected(view, "/riders/#{rider.id}")
       assert flash["info"] == "Rider updated successfully"
+    end
+
+    test "Logged in dispatcher can see dispatch-specific fields", %{conn: conn, rider: rider} do
+      {:ok, _view, html} = live(conn, ~p"/riders/#{rider.id}/show/edit")
+      assert html =~ "Send text-only delivery instructions"
+      assert html =~ "Flags"
+      assert html =~ "Last Safety Check"
+      assert html =~ "Notes (internal)"
     end
   end
 end


### PR DESCRIPTION
Closes #241 

- [?] Validate that the existing code works 
  - Seems fine to me? 
- [X] Make sure that you're only shown things that you have permission for (e.g. I shouldn't be able to add tags to my profile)
- [X] broken link on size: "small"
  - This was broken because the link would take the rider to a dispatch-only page.
  - I have removed this row of items as they are dispatcher specific. 

One issue remains, which is that it seems that riders are unable to actually _save_ their changes in the side `edit` panel when it opens - should this be possible? Or is this a bug?

## Screenshots (After)

![Profile _ Bike Brigade Dispatch](https://github.com/bikebrigade/dispatch/assets/12987958/a6a13055-c4c5-4595-bcbf-e7ba684849cd)


<img width="1263" alt="CleanShot 2023-10-26 at 15 48 50@2x" src="https://github.com/bikebrigade/dispatch/assets/12987958/f24e9a86-77f3-49f6-badd-0bd774c8420d">
