### PR TITLE
Add: allow rider to edit themselves.

### DIFF
--- a/lib/bike_brigade_web/live/rider_live/form_component.ex
+++ b/lib/bike_brigade_web/live/rider_live/form_component.ex
@@ -127,21 +127,9 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
     {:noreply, socket}
   end
 
-  defp save_rider(socket, :edit, rider_form_params) do
-    rider_form_params = Map.merge(%{"tags" => []}, rider_form_params)
-    with {:ok, form} <-
-           RiderForm.update_form(socket.assigns.form, rider_form_params),
-         params = RiderForm.to_params(form),
-         {:ok, _rider} <-
-           Riders.update_rider_with_tags(socket.assigns.rider, params, params[:tags]) do
-      {:noreply,
-       socket
-       |> put_flash(:info, "Rider updated successfully")
-       |> push_navigate(to: socket.assigns.navigate)}
-    else
-      _ -> {:noreply, assign(socket, :changeset, socket.assigns.changeset)}
-    end
-  end
+  defp save_rider(socket, :edit, rider_form_params), do: save_rider_edit_impl(socket, rider_form_params)
+  defp save_rider(socket, :edit_profile, rider_form_params), do: save_rider_edit_impl(socket, rider_form_params)
+
 
   defp save_rider(socket, :new, rider_params) do
     case Riders.create_rider_with_tags(rider_params, rider_params["tags"]) do
@@ -153,6 +141,23 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+
+  defp save_rider_edit_impl(socket, rider_form_params) do
+    rider_form_params = Map.merge(%{"tags" => []}, rider_form_params)
+    with {:ok, form} <-
+            RiderForm.update_form(socket.assigns.form, rider_form_params),
+          params = RiderForm.to_params(form),
+          {:ok, _rider} <-
+            Riders.update_rider_with_tags(socket.assigns.rider, params, params[:tags]) do
+              # IO.inspect({form, params})
+        {:noreply,
+        socket
+        |> put_flash(:info, "Rider updated successfully")
+        |> push_navigate(to: socket.assigns.navigate)}
+    else
+      _ -> {:noreply, assign(socket, :changeset, socket.assigns.changeset)}
     end
   end
 end

--- a/lib/bike_brigade_web/live/rider_live/form_component.ex
+++ b/lib/bike_brigade_web/live/rider_live/form_component.ex
@@ -30,21 +30,22 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
       belongs_to :location, Location, on_replace: :update
     end
 
-    def changeset(form, attrs \\ %{}) do
-      form
-      |> cast(attrs, [
-        :name,
-        :pronouns,
-        :email,
-        :phone,
-        :capacity,
-        :max_distance,
-        :last_safety_check,
-        :internal_notes,
-        :text_based_itinerary,
-        :tags
-      ])
-      |> cast_embed(:flags)
+    @shared_permitted_keys [
+      :name,
+      :pronouns,
+      :email,
+      :phone,
+      :capacity,
+      :max_distance
+    ]
+
+    @doc """
+    Dispatchers can edit a rider in their entirety; a rider can edit a
+    subsection of their profile. We handle both cases here by matching on what
+    the action is for the page.
+    """
+    def changeset(form, action, attrs \\ %{}) do
+      changeset_impl(form, action, attrs)
       |> cast_assoc(:location, with: &Location.geocoding_changeset/2)
       |> validate_required([
         :name,
@@ -54,6 +55,22 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
         :max_distance,
         :location
       ])
+    end
+
+    # `:edit` - the dispatcher is editing the rider
+    def changeset_impl(form, :edit, attrs) do
+      form
+      |> cast(
+        attrs,
+        @shared_permitted_keys() ++
+          [:last_safety_check, :internal_notes, :text_based_itinerary, :tags]
+      )
+      |> cast_embed(:flags)
+    end
+
+    # `:edit_profile` - the rider is editing their own profile.
+    def changeset_impl(form, :edit_profile, attrs) do
+      form |> cast(attrs, @shared_permitted_keys())
     end
 
     def from_rider(%Rider{} = rider) do
@@ -72,9 +89,9 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
       |> Map.update!(:flags, &Map.from_struct/1)
     end
 
-    def update_form(%__MODULE__{} = form, params) do
+    def update_form(%__MODULE__{} = form, action, params) do
       form
-      |> changeset(params)
+      |> changeset(action, params)
       |> apply_action(:save)
     end
   end
@@ -83,7 +100,7 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
   def update(%{rider: rider} = assigns, socket) do
     rider = rider |> Repo.preload(:tags)
     form = RiderForm.from_rider(rider)
-    changeset = RiderForm.changeset(form)
+    changeset = RiderForm.changeset(form, assigns.action)
 
     {:ok,
      socket
@@ -95,12 +112,12 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
 
   @impl true
   def handle_event("validate", %{"rider_form" => rider_form_params}, socket) do
-    case RiderForm.update_form(socket.assigns.form, rider_form_params) do
+    case RiderForm.update_form(socket.assigns.form, socket.assigns.action, rider_form_params) do
       {:ok, form} ->
         {:noreply,
          socket
          |> assign(:form, form)
-         |> assign(:changeset, RiderForm.changeset(form))}
+         |> assign(:changeset, RiderForm.changeset(form, socket.assigns.action))}
 
       {:error, changeset} ->
         {:noreply, assign(socket, :changeset, changeset)}
@@ -127,9 +144,13 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
     {:noreply, socket}
   end
 
-  defp save_rider(socket, :edit, rider_form_params), do: save_rider_edit_impl(socket, rider_form_params)
-  defp save_rider(socket, :edit_profile, rider_form_params), do: save_rider_edit_impl(socket, rider_form_params)
+  defp save_rider(socket, :edit, rider_form_params) do
+    save_rider_edit_impl(socket, rider_form_params)
+  end
 
+  defp save_rider(socket, :edit_profile, rider_form_params) do
+    save_rider_edit_impl(socket, rider_form_params)
+  end
 
   defp save_rider(socket, :new, rider_params) do
     case Riders.create_rider_with_tags(rider_params, rider_params["tags"]) do
@@ -146,16 +167,16 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
 
   defp save_rider_edit_impl(socket, rider_form_params) do
     rider_form_params = Map.merge(%{"tags" => []}, rider_form_params)
+
     with {:ok, form} <-
-            RiderForm.update_form(socket.assigns.form, rider_form_params),
-          params = RiderForm.to_params(form),
-          {:ok, _rider} <-
-            Riders.update_rider_with_tags(socket.assigns.rider, params, params[:tags]) do
-              # IO.inspect({form, params})
-        {:noreply,
-        socket
-        |> put_flash(:info, "Rider updated successfully")
-        |> push_navigate(to: socket.assigns.navigate)}
+           RiderForm.update_form(socket.assigns.form, socket.assigns.action, rider_form_params),
+         params = RiderForm.to_params(form),
+         {:ok, _rider} <-
+           Riders.update_rider_with_tags(socket.assigns.rider, params, params[:tags]) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Rider updated successfully")
+       |> push_navigate(to: socket.assigns.navigate)}
     else
       _ -> {:noreply, assign(socket, :changeset, socket.assigns.changeset)}
     end

--- a/test/bike_brigade_web/live/rider_live_test.exs
+++ b/test/bike_brigade_web/live/rider_live_test.exs
@@ -93,7 +93,6 @@ defmodule BikeBrigadeWeb.RiderLiveTest do
       refute html =~ "Notes (internal)"
     end
 
-
     test "Logged in rider can edit their profile.", %{conn: conn, rider: rider} do
       {:ok, view, html} = live(conn, ~p"/profile/edit")
       assert html =~ rider.name
@@ -105,10 +104,33 @@ defmodule BikeBrigadeWeb.RiderLiveTest do
       flash = assert_redirected(view, "/profile")
       assert flash["info"] == "Rider updated successfully"
 
-      {:ok, view, html} = live(conn, ~p"/profile")
-      open_browser view
+      {:ok, _view, html} = live(conn, ~p"/profile")
       assert html =~ "alex123"
+    end
 
+    test "Logged in rider cannot edit admin fields.", %{conn: conn, rider: rider} do
+      {:ok, view, html} = live(conn, ~p"/profile/edit")
+      assert html =~ rider.name
+      error_msg_regex = ~r/could not find non-disabled input, select or textarea/
+
+      assert_raise ArgumentError, error_msg_regex, fn ->
+        view |> form("#rider-form", rider_form: %{"internal_notes" => "notes!"}) |> render_submit()
+      end
+
+      assert_raise ArgumentError,  error_msg_regex, fn ->
+        view |> form("#rider-form", rider_form: %{"last_safety_check" => "2023-11-21"}) |> render_submit()
+      end
+
+      assert_raise ArgumentError,  error_msg_regex, fn ->
+        view
+        |> form("#rider-form", rider_form: %{"text_based_itinerary" => "false"}) |> render_submit()
+      end
+
+      assert_raise ArgumentError,  error_msg_regex, fn ->
+        view
+        |> form("#rider-form", rider_form: %{"tags" => ["foo"]})
+        |> render_submit()
+      end
     end
   end
 
@@ -121,6 +143,20 @@ defmodule BikeBrigadeWeb.RiderLiveTest do
       assert html =~ rider.name
       assert html =~ rider.location.address
       assert html =~ "dispatch-data-tags-and-capacity"
+    end
+
+
+    test "Logged in dispatcher can edit admin-only fields.", %{conn: conn, rider: rider} do
+      {:ok, view, html} = live(conn, ~p"/riders/#{rider}/show/edit")
+      assert html =~ rider.name
+
+        view
+        |> form("#rider-form", rider_form: %{
+              "name" => "alex123",
+              "internal_notes" => "notes!",
+              "last_safety_check" => "2023-11-21",
+              "text_based_itinerary" => "false"})
+        |> render_submit()
     end
 
 

--- a/test/bike_brigade_web/live/rider_live_test.exs
+++ b/test/bike_brigade_web/live/rider_live_test.exs
@@ -23,7 +23,7 @@ defmodule BikeBrigadeWeb.RiderLiveTest do
 
     test "searching riders works", %{conn: conn} do
       fixture(:rider, %{name: "Béa"})
-      {:ok, index_live, html} = live(conn, ~p"/riders")
+      {:ok, index_live, _html} = live(conn, ~p"/riders")
 
       html = index_live
       |> element("#rider-search")
@@ -85,12 +85,30 @@ defmodule BikeBrigadeWeb.RiderLiveTest do
   describe "Edit: rider logged-in" do
     setup [:create_rider, :login_as_rider]
 
-    test "Logged in rider cannot dispatch specific fields in slideover", %{conn: conn} do
+    test "Logged in rider cannot see dispatch-specific fields in slideover", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/profile/edit")
       refute html =~ "Send text-only delivery instructions"
       refute html =~ "Flags"
       refute html =~ "Last Safety Check"
       refute html =~ "Notes (internal)"
+    end
+
+
+    test "Logged in rider can edit their profile.", %{conn: conn, rider: rider} do
+      {:ok, view, html} = live(conn, ~p"/profile/edit")
+      assert html =~ rider.name
+
+      view
+      |> form("#rider-form", rider_form: %{"name" => "alex123"})
+      |> render_submit()
+
+      flash = assert_redirected(view, "/profile")
+      assert flash["info"] == "Rider updated successfully"
+
+      {:ok, view, html} = live(conn, ~p"/profile")
+      open_browser view
+      assert html =~ "alex123"
+
     end
   end
 


### PR DESCRIPTION
Closes #249.

I noticed that in the routes file, the dispatch route for [editing a rider](https://github.com/bikebrigade/dispatch/blob/6d2c710e843325da2f9839c4da4623b3e8e5f6b5/lib/bike_brigade_web/router.ex#L153) has an action of `:edit`, whereas the route for [riders' action is ](https://github.com/bikebrigade/dispatch/blob/6d2c710e843325da2f9839c4da4623b3e8e5f6b5/lib/bike_brigade_web/router.ex#L103)`:edit_profile`
 
I assumed this was intentional, which is why I created a `save_rider_edit_impl`. It it's not, I can remove most of the code and make sure both pages use the same action.
