### PR TITLE
Add: Itinerary page

### DIFF
--- a/lib/bike_brigade_web/components/layouts.ex
+++ b/lib/bike_brigade_web/components/layouts.ex
@@ -64,7 +64,7 @@ defmodule BikeBrigadeWeb.Layouts do
       </.sidebar_link>
       <!-- Rider Specific links -->
       <div :if={!@is_dispatcher}>
-        <.sidebar_link selected={@current_page == :itineraries} href={~p"/itinerary"}>
+        <.sidebar_link selected={@current_page == :itinerary} href={~p"/itinerary"}>
           <:icon>
             <Heroicons.calendar_days solid />
           </:icon>

--- a/lib/bike_brigade_web/components/layouts.ex
+++ b/lib/bike_brigade_web/components/layouts.ex
@@ -62,6 +62,16 @@ defmodule BikeBrigadeWeb.Layouts do
         </:icon>
         My Profile
       </.sidebar_link>
+      <!-- Rider Specific links -->
+      <div :if={!@is_dispatcher}>
+        <.sidebar_link selected={@current_page == :itineraries} href={~p"/itinerary"}>
+          <:icon>
+            <Heroicons.calendar_days solid />
+          </:icon>
+          Itinerary
+        </.sidebar_link>
+      </div>
+
       <.sidebar_link selected={@current_page == :logout} href={~p"/logout"} method="post">
         <:icon>
           <Heroicons.arrow_left_on_rectangle solid />

--- a/lib/bike_brigade_web/live/itinerary_live/index.html.heex
+++ b/lib/bike_brigade_web/live/itinerary_live/index.html.heex
@@ -45,51 +45,55 @@
   </div>
 </nav>
 <%= if @campaign_riders != [] do %>
-  <div class="flex flex-col mt-8">
-    <%= for cr <- @campaign_riders do %>
-      <div class="flex w-full bg-white shadow my-1 rounded-md mb-4">
-        <ul role="list" class="w-full divide-y divide-gray-200">
-          <li id={"campaign-#{cr.campaign.id}"} class="mb-4">
-            <div class="px-4 py-4">
-              <div class="items-center justify-between md:flex">
-                <div class="flex items-center mb-2 space-x-1">
-                  <div class="font-bold"><%= name(cr.campaign) %></div>
-                </div>
-                <div class="flex-shrink-0 space-y-1 md:space-y-0 md:space-x-2 md:flex">
-                  <.button navigate={~p"/app/delivery/#{cr.token}"} size={:medium}>
-                    Details
-                  </.button>
-                </div>
+    <div :for={cr <- @campaign_riders} class="flex w-full bg-white shadow sm:my-1 sm:rounded-md">
+      <ul role="list" class="w-full divide-y divide-gray-200">
+        <li id={"campaign-#{cr.campaign.id}"}>
+          <div class="px-4 py-4">
+            <div class="items-center justify-between md:flex">
+              <div class="flex items-center mb-2 space-x-1">
+                <.link
+                  navigate={~p"/campaigns/#{cr.campaign}"}
+                  class="font-bold link"
+                >
+                  <%= name(cr.campaign) %>
+                </.link>
               </div>
-              <div class="mt-2 sm:flex sm:justify-between">
-                <div class="sm:flex">
-                  <p class="flex items-center text-sm text-gray-500">
-                    <Heroicons.clock
-                      aria-label="Pickup Time"
-                      class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
-                    />
-                    <%= pickup_window(cr.campaign) %>
-                  </p>
-                </div>
-              </div>
-              <.get_location campaign={cr.campaign} />
-              <div class="mt-2 sm:flex sm:justify-between">
-                <div class="sm:flex">
-                  <p class="flex items-center text-sm text-gray-500">
-                    <Heroicons.shopping_bag
-                      aria-label="Location"
-                      class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
-                    />
-                    <%= humanized_task_count(cr.campaign.tasks) %>
-                  </p>
-                </div>
+              <div class="flex-shrink-0 space-y-1 md:space-y-0 md:space-x-2 md:flex">
+                <.button
+                  navigate={~p"/app/delivery/#{cr.token}"}
+                  size={:medium}
+                >
+                  Details
+                </.button>
               </div>
             </div>
-          </li>
-        </ul>
-      </div>
-    <% end %>
-  </div>
+            <div class="mt-2 sm:flex sm:justify-between">
+              <div class="sm:flex">
+                <p class="flex items-center text-sm text-gray-500">
+                  <Heroicons.clock
+                    aria-label="Pickup Time"
+                    class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
+                  />
+                  <%= pickup_window(cr.campaign) %>
+                </p>
+              </div>
+            </div>
+            <.get_location campaign={cr.campaign} />
+            <div class="mt-2 sm:flex sm:justify-between">
+              <div class="sm:flex">
+                <p class="flex items-center text-sm text-gray-500">
+                  <Heroicons.shopping_bag
+                    aria-label="Location"
+                    class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
+                  />
+                  <%= humanized_task_count(cr.campaign.tasks) %>
+                </p>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
 <% else %>
   <div class="py-4 pl-4">No campaigns found for this day.</div>
 <% end %>

--- a/lib/bike_brigade_web/live/itinerary_live/index.html.heex
+++ b/lib/bike_brigade_web/live/itinerary_live/index.html.heex
@@ -1,5 +1,5 @@
 <nav
-  class="flex items-end justify-between px-4 py-3 mb-1 border-b-2 border-gray-200"
+  class="flex items-end justify-between px-4 py-3 border-b-2 border-gray-200 mb-4"
   aria-label="Pagination"
 >
   <div class="items-center block font-medium xl:flex">
@@ -45,7 +45,7 @@
   </div>
 </nav>
 <%= if @campaign_riders != [] do %>
-    <div :for={cr <- @campaign_riders} class="flex w-full bg-white shadow sm:my-1 sm:rounded-md">
+    <div :for={cr <- @campaign_riders} class="flex w-full bg-white shadow mb-2 md:mb-4 sm:rounded-md">
       <ul role="list" class="w-full divide-y divide-gray-200">
         <li id={"campaign-#{cr.campaign.id}"}>
           <div class="px-4 py-4">

--- a/lib/bike_brigade_web/live/itinerary_live/index.html.heex
+++ b/lib/bike_brigade_web/live/itinerary_live/index.html.heex
@@ -45,57 +45,51 @@
   </div>
 </nav>
 <%= if @campaign_riders != [] do %>
-  <%= for cr <- @campaign_riders do %>
-    <div class="flex w-full bg-white shadow sm:my-1 sm:rounded-md">
-      <ul role="list" class="w-full divide-y divide-gray-200">
-        <li id={"campaign-#{cr.campaign.id}"}>
-          <div class="px-4 py-4">
-            <div class="items-center justify-between md:flex">
-              <div class="flex items-center mb-2 space-x-1">
-                <.link
-                  navigate={~p"/campaigns/#{cr.campaign}"}
-                  class="font-bold link"
-                >
-                  <%= name(cr.campaign) %>
-                </.link>
+  <div class="flex flex-col mt-8">
+    <%= for cr <- @campaign_riders do %>
+      <div class="flex w-full bg-white shadow my-1 rounded-md mb-4">
+        <ul role="list" class="w-full divide-y divide-gray-200">
+          <li id={"campaign-#{cr.campaign.id}"} class="mb-4">
+            <div class="px-4 py-4">
+              <div class="items-center justify-between md:flex">
+                <div class="flex items-center mb-2 space-x-1">
+                  <div class="font-bold"><%= name(cr.campaign) %></div>
+                </div>
+                <div class="flex-shrink-0 space-y-1 md:space-y-0 md:space-x-2 md:flex">
+                  <.button navigate={~p"/app/delivery/#{cr.token}"} size={:medium}>
+                    Details
+                  </.button>
+                </div>
               </div>
-              <div class="flex-shrink-0 space-y-1 md:space-y-0 md:space-x-2 md:flex">
-                <.button
-                  navigate={~p"/app/delivery/#{cr.token}"}
-                  size={:medium}
-                >
-                  Details
-                </.button>
+              <div class="mt-2 sm:flex sm:justify-between">
+                <div class="sm:flex">
+                  <p class="flex items-center text-sm text-gray-500">
+                    <Heroicons.clock
+                      aria-label="Pickup Time"
+                      class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
+                    />
+                    <%= pickup_window(cr.campaign) %>
+                  </p>
+                </div>
               </div>
-            </div>
-            <div class="mt-2 sm:flex sm:justify-between">
-              <div class="sm:flex">
-                <p class="flex items-center text-sm text-gray-500">
-                  <Heroicons.clock
-                    aria-label="Pickup Time"
-                    class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
-                  />
-                  <%= pickup_window(cr.campaign) %>
-                </p>
-              </div>
-            </div>
-            <.get_location campaign={cr.campaign} />
-            <div class="mt-2 sm:flex sm:justify-between">
-              <div class="sm:flex">
-                <p class="flex items-center text-sm text-gray-500">
-                  <Heroicons.shopping_bag
-                    aria-label="Location"
-                    class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
-                  />
-                  <%= humanized_task_count(cr.campaign.tasks) %>
-                </p>
+              <.get_location campaign={cr.campaign} />
+              <div class="mt-2 sm:flex sm:justify-between">
+                <div class="sm:flex">
+                  <p class="flex items-center text-sm text-gray-500">
+                    <Heroicons.shopping_bag
+                      aria-label="Location"
+                      class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
+                    />
+                    <%= humanized_task_count(cr.campaign.tasks) %>
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        </li>
-      </ul>
-    </div>
-  <% end %>
+          </li>
+        </ul>
+      </div>
+    <% end %>
+  </div>
 <% else %>
   <div class="py-4 pl-4">No campaigns found for this day.</div>
 <% end %>

--- a/lib/bike_brigade_web/router.ex
+++ b/lib/bike_brigade_web/router.ex
@@ -85,7 +85,7 @@ defmodule BikeBrigadeWeb.Router do
     get "/", Plugs.RedirectUser,
       unauthenticated: [to: "/login"],
       dispatcher: [to: "/campaigns"],
-      default: [to: "/profile"]
+      default: [to: "/itinerary"]
   end
 
   scope "/", BikeBrigadeWeb do
@@ -106,7 +106,6 @@ defmodule BikeBrigadeWeb.Router do
     end
 
     post "/logout", Authentication, :logout
-
   end
 
   scope "/", BikeBrigadeWeb do


### PR DESCRIPTION
I thought there would be more to do in building the itinerary page, but I think a lot of it was already done. 

This PR adds:

- "Itinerary" to the sidebar for riders
- remove ability to link to the campaign directly, since that's unauthorized for riders.
- on rider logging in, redirect them to the `/itinerary` route. 

If I understand correctly, this maybe closes #136? 

-----

![Itinerary _ Bike Brigade Dispatch](https://github.com/bikebrigade/dispatch/assets/12987958/f71e07c7-a624-42f4-bd29-a4dfd6c6bce2)

