### PR TITLE
Break search grid to 1 column col on mobile.

### DIFF
--- a/lib/bike_brigade_web/live/rider_live/index.ex
+++ b/lib/bike_brigade_web/live/rider_live/index.ex
@@ -457,7 +457,7 @@ defmodule BikeBrigadeWeb.RiderLive.Index do
       phx-key="escape"
     >
       <p class="text-sm text-gray-500">Press Tab to cycle suggestions</p>
-      <div class="grid grid-cols-2 gap-1">
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-1">
         <div>
           <%= if @suggestions.name do %>
             <h3 class="my-1 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">


### PR DESCRIPTION
Addresses #257 

This small change drops the search grid to one column on mobile:

https://github.com/bikebrigade/dispatch/assets/12987958/0f6b5951-52da-48d9-a707-f5c11a3e1947

I tried additionally widening the search to `130%` on large screens and up. I did not commit this, but here's what it looks like:

https://github.com/bikebrigade/dispatch/assets/12987958/1fc4d030-9a0d-4b70-983a-2d96eca20a52

Which would be done by the following:

```
    <dialog
      id="suggestion-list"
      open={@open}
      class="absolute z-10 w-full lg:w-[130%]  p-2 mt-0 overflow-y-auto bg-white border rounded shadow-xl top-100 max-h-fit"
      phx-window-keydown="clear_search"
      phx-key="escape"
    >
```