### PR TITLE
Make campaign signup more mobile friendly

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -332,6 +332,7 @@ defmodule BikeBrigade.Delivery do
         select: t
       )
       |> task_load_location()
+      |> order_by(:id)
       |> Repo.all()
       |> Repo.preload([:pickup_location, :dropoff_location, task_items: [:item]])
 

--- a/lib/bike_brigade_web/components/layouts/app.html.heex
+++ b/lib/bike_brigade_web/components/layouts/app.html.heex
@@ -1,4 +1,17 @@
 <div>
+  <div class="flex w-full bg-white border-b">
+    <div class="absolute top-0 z-10 bg-white  md:hidden">
+      <button
+        phx-click={open_mobile_menu()}
+        type="button"
+        class="inline-flex h-12 w-12 items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+      >
+        <span class="sr-only">Open sidebar</span>
+        <Heroicons.bars_3 class="w-6 h-6" />
+      </button>
+    </div>
+    <div class="w-full md:hidden text-center p-3 text-gray-600"><%= @page_title %></div>
+  </div>
   <!-- Off-canvas menu for mobile, show/hide based on off-canvas menu state. -->
   <div id="mobile-menu-container" class="relative z-40 hidden " role="dialog" aria-modal="true">
     <!--
@@ -139,16 +152,6 @@
     </div>
   </div>
   <div class="flex flex-col flex-1 md:pl-64">
-    <div class="sticky top-0 z-10 pt-1 pl-1 bg-gray-50 sm:pl-3 sm:pt-3 md:hidden">
-      <button
-        phx-click={open_mobile_menu()}
-        type="button"
-        class="-ml-0.5 -mt-0.5 inline-flex h-12 w-12 items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
-      >
-        <span class="sr-only">Open sidebar</span>
-        <Heroicons.bars_3 class="w-6 h-6" />
-      </button>
-    </div>
     <main class="flex-1">
       <div class="py-6">
         <div class="px-4 mx-auto max-w-7xl sm:px-6 md:px-8">
@@ -163,8 +166,7 @@
             phx-disconnected={show("#disconnected")}
             phx-connected={hide("#disconnected")}
           >
-          Reconnecting....
-            <Heroicons.arrow_path class="inline w-3 h-3 ml-1 animate-spin" />
+            Reconnecting.... <Heroicons.arrow_path class="inline w-3 h-3 ml-1 animate-spin" />
           </.flash>
           <%= @inner_content %>
         </div>

--- a/lib/bike_brigade_web/core_components.ex
+++ b/lib/bike_brigade_web/core_components.ex
@@ -145,11 +145,12 @@ defmodule BikeBrigadeWeb.CoreComponents do
 
   """
   attr :date, Date, required: true
+  attr :class, :string, default: ""
   attr :rest, :global, include: ~w(href patch navigate)
 
   def date(%{rest: rest} = assigns) when is_clickable(rest) do
     ~H"""
-    <.link class="inline-flex border border-gray-400 rounded hover:bg-indigo-50" {@rest}>
+    <.link class={"inline-flex border border-gray-400 rounded hover:bg-indigo-50 #{@class}"} {@rest}>
       <.date_inner date={@date} />
     </.link>
     """
@@ -157,7 +158,7 @@ defmodule BikeBrigadeWeb.CoreComponents do
 
   def date(assigns) do
     ~H"""
-    <div class="inline-flex border border-gray-400 rounded" {@rest}>
+    <div class={"inline-flex border border-gray-400 rounded #{@class}"} {@rest}>
       <.date_inner date={@date} />
     </div>
     """
@@ -1139,7 +1140,7 @@ defmodule BikeBrigadeWeb.CoreComponents do
                     :if={@action != []}
                     class="py-4 pl-2 pr-4 text-sm font-medium text-right sm:pr-6"
                   >
-                    <span :for={action <- @action} class="ml-1">
+                    <span :for={action <- @action} class="ml-1 flex">
                       <%= render_slot(action, row) %>
                     </span>
                   </td>

--- a/lib/bike_brigade_web/helpers/campaign_helpers.ex
+++ b/lib/bike_brigade_web/helpers/campaign_helpers.ex
@@ -112,6 +112,16 @@ defmodule BikeBrigadeWeb.CampaignHelpers do
     end
   end
 
+  def campaign_in_past(campaign) do
+    date_now = DateTime.utc_now()
+
+    case DateTime.compare(campaign.delivery_end, date_now) do
+      :gt -> false
+      :eq -> false
+      :lt -> true
+    end
+  end
+
   # TODO this could be better
   defp print_item(task_item) do
     "#{task_item.count} #{Inflex.inflect(task_item.item.name, task_item.count)}"

--- a/lib/bike_brigade_web/live/campaign_signup_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/index.ex
@@ -94,38 +94,100 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
     |> assign(:campaigns, fetch_campaigns(week))
   end
 
-  defp campaign_is_in_past(campaign) do
-    date_now = DateTime.utc_now()
-
-    case DateTime.compare(campaign.delivery_end, date_now) do
-      :gt -> false
-      :eq -> false
-      :lt -> true
-    end
-  end
-
-  defp get_signup_text(campaign_id, rider_id, campaign_task_counts) do
-    count_tasks_for_current_rider =
-      campaign_task_counts[campaign_id].rider_ids_counts[rider_id] || 0
-
-    cond do
-      count_tasks_for_current_rider > 0 ->
-        "Signed up for #{count_tasks_for_current_rider} deliveries"
-
-      true ->
-        "Sign up"
-    end
-  end
-
-  defp campaign_tasks_fully_assigned?(c_id, campaign_task_count) do
-    campaign_task_count[c_id][:filled_tasks] == campaign_task_count[c_id][:total_tasks]
-  end
-
   # Use this to determine if we need to refetch data to update the liveview.
   # ex: dispatcher changes riders/tasks, or another rider signs up -> refetch.
   defp entity_in_campaigns?(socket, entity_campaign_id) do
     socket.assigns.campaigns
     |> Enum.flat_map(fn {_date, campaigns} -> campaigns end)
     |> Enum.find(false, fn c -> c.id == entity_campaign_id end)
+  end
+
+  attr :filled_tasks, :integer, required: true
+  attr :total_tasks, :integer, required: true
+  attr :campaign, :any, required: true
+
+  defp tasks_filled_text(assigns) do
+    copy =
+      if assigns.filled_tasks == nil do
+        "N/A"
+      else
+        "#{assigns.total_tasks - assigns.filled_tasks} Available"
+      end
+
+    assigns = assign(assigns, :copy, copy)
+
+    ~H"""
+    <p class="flex flex-col md:flex-row items-center mt-0 text-sm text-gray-700">
+      <Icons.maki_bicycle_share class="flex-shrink-0 mb-2 mr-1.5 h-8 w-8 md:h-5 md:w-5 md:mb-0 text-gray-500" />
+      <span class="flex space-x-2 font-bold md:font-normal">
+        <span><%= @copy %></span>
+      </span>
+    </p>
+    """
+  end
+
+  attr :campaign, :any, required: true
+  attr :rider_id, :integer, required: true
+  attr :campaign_task_counts, :any, required: true
+
+  defp signup_button(assigns) do
+    c = assigns.campaign
+    filled_tasks = assigns.campaign_task_counts[c.id][:filled_tasks]
+    total_tasks = assigns.campaign_task_counts[c.id][:total_tasks]
+    date_now = DateTime.utc_now()
+    campaign_tasks_fully_assigned? = filled_tasks == total_tasks
+    campaign_not_ready_for_signup? = is_nil(total_tasks)
+
+    current_rider_task_count =
+      if is_nil(total_tasks) do
+        0
+      else
+        assigns.campaign_task_counts[c.id].rider_ids_counts[assigns.rider_id] || 0
+      end
+
+    campaign_in_past =
+      case DateTime.compare(assigns.campaign.delivery_end, date_now) do
+        :gt -> false
+        :eq -> false
+        :lt -> true
+      end
+
+    # Define map for button properties
+    button_properties = %{
+      in_past: {:disabled, "Completed"},
+      not_ready: {:disabled, "Campaign not ready for signup"},
+      fully_assigned: {:secondary, "Campaign Filled"},
+      rider_is_assigned: {:secondary, "Signed up for #{current_rider_task_count} deliveries"},
+      default: {:secondary, "Sign up"}
+    }
+
+    buttonType =
+      cond do
+        current_rider_task_count > 0 -> :rider_is_assigned
+        campaign_not_ready_for_signup? -> :not_ready
+        campaign_tasks_fully_assigned? -> :fully_assigned
+        campaign_in_past -> :in_past
+        true -> :default
+      end
+
+    # Extract button properties based on buttonType
+    {button_color, signup_text} = Map.fetch!(button_properties, buttonType)
+
+    assigns =
+      assigns
+      |> assign(:signup_text, signup_text)
+      |> assign(:button_color, button_color)
+      |> assign(:c, c)
+
+    ~H"""
+    <.button
+      size={:small}
+      class="w-full rounded-none md:rounded-sm"
+      color={@button_color}
+      navigate={~p"/campaigns/signup/#{@c}/"}
+    >
+      <%= @signup_text %>
+    </.button>
+    """
   end
 end

--- a/lib/bike_brigade_web/live/campaign_signup_live/index.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/index.html.heex
@@ -1,17 +1,9 @@
 <nav
-  class="flex flex-col md:flex-row md:items-center justify-between px-4 py-3 mb-4 border-b-2 border-gray-200"
+  class="flex flex-col md:flex-row md:items-center justify-between md:px-4 md:py-3 md:mb-4 md:border-b-2 md:border-gray-200 md:justify-end"
   aria-label="Pagination"
 >
-  <div class="flex-1">
-    <p class="text-sm text-gray-700">
-      Showing week of
-      <time datetime={@current_week} class="font-medium">
-        <%= Calendar.strftime(@current_week, "%B %-d, %Y") %>
-      </time>
-    </p>
-  </div>
-  <div class="flex justify-between mt-4 md:mt-0 align-end">
-    <span class="relative z-0 inline-flex rounded-md shadow-sm">
+  <div class="flex justify-between md:my-4 align-end">
+    <span class="relative z-0 w-full inline-flex rounded-md shadow-sm">
       <.link
         patch={~p"/campaigns/signup?current_week=#{Date.add(@current_week, -7)}"}
         class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-l-md hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
@@ -19,10 +11,13 @@
         <Heroicons.chevron_left solid class="w-5 h-5" />
       </.link>
       <.link
-        patch={~p"/campaigns/signup?current_week=#{Date.beginning_of_week(LocalizedDateTime.today())}"}
-        class="relative items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 sm:inline-flex hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+        patch={
+          ~p"/campaigns/signup?current_week=#{Date.beginning_of_week(LocalizedDateTime.today())}"
+        }
+        class="w-full text-center relative items-center px-4 py-2  text-sm font-medium text-gray-700 bg-white border border-gray-300  hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
       >
-        Today
+
+      Week of <%= Calendar.strftime(@current_week, "%B %-d") %>
       </.link>
 
       <.link
@@ -34,71 +29,66 @@
     </span>
   </div>
 </nav>
+
 <%= if @campaigns != [] do %>
   <%= for {date, campaigns} <- @campaigns do %>
-    <div class="flex flex-col md:flex-row w-full bg-white shadow sm:my-1 sm:rounded-md">
-      <div class="w-32 py-4 pl-4">
-        <.date date={date} />
+    <div class="flex flex-col lg:flex-row w-full sm:my-1 sm:rounded-md mb-4 md:mb-0 lg:mb-8">
+      <div class="flex w-full lg:w-40 justify-center  py-4 my-4 lg:py-0 lg:my-0">
+        <div class="flex w-full items-center lg:items-start">
+          <div class="md:hidden flex-1 border-t-2 border-gray-300"></div>
+          <span class="px-3">
+            <.date date={date} />
+          </span>
+          <div class="md:hidden flex-1 border-t-2 border-gray-300"></div>
+        </div>
       </div>
+
       <ul role="list" class="w-full divide-y divide-gray-200">
         <%= for c <- campaigns do %>
-          <li id={"campaign-#{c.id}"}>
-            <div class="px-4 py-4">
-              <div class="items-center justify-between md:flex">
-                <div class="flex items-center mb-2 space-x-1">
-                  <p
-                    class="text-sm font-medium"
-                    data-test-group="campaign-name"
-                  >
-                    <%= name(c) %>
-                  </p>
-                </div>
-                <div class="flex-shrink-0 space-y-1 md:space-y-0 md:space-x-2 md:flex">
-                  <%= cond do %>
-                    <% campaign_is_in_past(c) -> %>
-                      <.button
-                        size={:xsmall}
-                        color={:disabled}>
-                        Completed
-                      </.button>
+          <li id={"campaign-#{c.id}"} class="bg-white shadow mb-8 border last:mb-0">
+            <div class="flex items-center space-x-1 px-4 py-2 bg-slate-100">
+              <div
+                class="flex items-center justify-between w-full text-sm"
+                data-test-group="campaign-name"
+              >
+                <span class="font-medium truncate"><%= name(c) %></span>
+                <.date class="border-none opacity-80" date={date} />
+              </div>
+            </div>
 
-                    <% campaign_tasks_fully_assigned?(c.id, @campaign_task_counts) -> %>
-                      <.button
-                        size={:xsmall}
-                        color={:secondary}
-                        navigate={~p"/campaigns/signup/#{c}/"}>
-                        Campaign Filled
-                      </.button>
-
-                    <% true -> %>
-                    <.button
-                        size={:xsmall}
-                        color={:primary}
-                        navigate={~p"/campaigns/signup/#{c}/"}>
-                        <%= get_signup_text(c.id, @current_user.rider_id, @campaign_task_counts) %>
-                      </.button>
-                  <% end %>
+            <div class="flex flex-col md:flex-row md:px-4 ">
+              <div class="order-2  items-center justify-between md:flex md:flex-3">
+                <div class="flex-shrink-0 md:space-x-2 md:flex">
+                  <div class="md:mt-0">
+                    <.signup_button
+                      rider_id={@current_user.rider_id}
+                      campaign_task_counts={@campaign_task_counts}
+                      campaign={c}
+                    />
+                  </div>
                 </div>
               </div>
-              <div class="mt-2 sm:flex sm:justify-between">
-                <div class="flex flex-col md:flex-row justify-between w-full">
-
-                  <p class="flex items-center mt-0 text-sm text-gray-700">
-                    <Icons.maki_bicycle_share class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-500" />
-                    <span>
-                      <%= @campaign_task_counts[c.id][:filled_tasks] %> /
-                      <%= @campaign_task_counts[c.id][:total_tasks] %> Tasks filled
-                    </span>
-                  </p>
-
-                  <p class="flex items-center text-sm text-gray-700">
-                    <Heroicons.clock
-                      mini
-                      aria-label="Pickup Time"
-                      class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-500"
+              <div class="order-1 flex-1 sm:flex sm:justify-between">
+                <div class="flex flex-row divide-x-2 md:divide-x-0 justify-around py-4 w-full">
+                  <div class="flex-1">
+                    <.tasks_filled_text
+                      filled_tasks={@campaign_task_counts[c.id][:filled_tasks]}
+                      total_tasks={@campaign_task_counts[c.id][:total_tasks]}
+                      campaign={c}
                     />
-                    Pickup time: <%= pickup_window(c) %>
-                  </p>
+                  </div>
+
+                  <div class="flex-1">
+                    <p class="flex flex-col md:flex-row items-center mt-0 text-sm text-gray-700">
+                      <Heroicons.clock
+                        aria-label="pickup time"
+                        class="flex-shrink-0 mb-2 mr-1.5 h-8 w-8 md:h-5 md:w-5 md:mb-0 text-gray-500"
+                      />
+                      <span class="flex space-x-2 font-bold md:font-normal">
+                        <%= pickup_window(c) %>
+                      </span>
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -108,5 +98,5 @@
     </div>
   <% end %>
 <% else %>
-  <div class="pt-1 pl-4">No campaigns found</div>
+  <div class="flex items-center justify-center h-96 w-4/5 mx-auto text-center">No campaigns set up yet for the week of <%= Calendar.strftime(@current_week, "%B %-d") %>.</div>
 <% end %>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -207,4 +207,38 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
       """
     end
   end
+
+  defp signup_button(assigns) do
+    ~H"""
+    <div>
+      <%= if @task.assigned_rider do %>
+        <span :if={@task.assigned_rider.id != @current_rider_id} class="mr-2">
+          <%= split_first_name(@task.assigned_rider.name) %>
+        </span>
+
+        <.button
+          :if={@task.assigned_rider.id == @current_rider_id}
+          phx-click={JS.push("unassign_task", value: %{task_id: @task.id})}
+          color={:red}
+          size={:xsmall}
+          class="w-full md:w-28"
+        >
+          Unassign me
+        </.button>
+      <% end %>
+
+      <%= if is_nil(@task.assigned_rider) do %>
+        <.button
+          phx-click={JS.push("signup_rider", value: %{task_id: @task.id, rider_id: @current_rider_id})}
+          color={:secondary}
+          size={:xsmall}
+          class="w-full md:w-28"
+          replace
+        >
+          Signup
+        </.button>
+      <% end %>
+    </div>
+    """
+  end
 end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -219,6 +219,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
         <.button
           :if={@task.assigned_rider.id == @current_rider_id}
           phx-click={JS.push("unassign_task", value: %{task_id: @task.id})}
+          id={"#{@id}-unassign-task-#{@task.id}"}
           color={:red}
           size={:xsmall}
           class="w-full md:w-28"
@@ -231,11 +232,12 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
         <.button
           phx-click={JS.push("signup_rider", value: %{task_id: @task.id, rider_id: @current_rider_id})}
           color={:secondary}
+          id={"#{@id}-sign-up-task-#{@task.id}"}
           size={:xsmall}
           class="w-full md:w-28"
           replace
         >
-          Signup
+          Sign up
         </.button>
       <% end %>
     </div>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -208,9 +208,23 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     end
   end
 
+  @doc"""
+    Shows one of the following:
+    - A "Sign up" button if the campaign is eligible for signing up
+    - A "Unassign me" button if a rider is assigned to a task and wants to unassign themselves
+    - The first name of other riders who have signed up for tasks.
+  """
+
+
+  attr :task, :any, required: true
+
+  attr :campaign, :any, required: true
+  attr :current_rider_id, :integer, required: true
+  attr :id, :string, required: true
   defp signup_button(assigns) do
     ~H"""
     <div>
+
       <%= if @task.assigned_rider do %>
         <span :if={@task.assigned_rider.id != @current_rider_id} class="mr-2">
           <%= split_first_name(@task.assigned_rider.name) %>
@@ -228,7 +242,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
         </.button>
       <% end %>
 
-      <%= if is_nil(@task.assigned_rider) do %>
+      <%= if task_eligible_for_signup(@task, @campaign) do %>
         <.button
           phx-click={JS.push("signup_rider", value: %{task_id: @task.id, rider_id: @current_rider_id})}
           color={:secondary}
@@ -242,5 +256,10 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
       <% end %>
     </div>
     """
+  end
+
+  defp task_eligible_for_signup(task, campaign) do
+    # campaign not in past, assigned rider not nil.
+    task.assigned_rider == nil && !campaign_in_past(campaign)
   end
 end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -231,7 +231,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
         </span>
 
         <.button
-          :if={@task.assigned_rider.id == @current_rider_id}
+          :if={task_eligigle_for_unassign(@task, @campaign, @current_rider_id)}
           phx-click={JS.push("unassign_task", value: %{task_id: @task.id})}
           id={"#{@id}-unassign-task-#{@task.id}"}
           color={:red}
@@ -261,5 +261,10 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
   defp task_eligible_for_signup(task, campaign) do
     # campaign not in past, assigned rider not nil.
     task.assigned_rider == nil && !campaign_in_past(campaign)
+  end
+
+  # determine if a rider is eligible to "unassign" themselves
+  defp task_eligigle_for_unassign(task, campaign, current_rider_id) do
+    task.assigned_rider.id == current_rider_id && !campaign_in_past(campaign)
   end
 end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -9,9 +9,11 @@
     <span :if={@campaign.program.campaign_blurb}>- <%= @campaign.program.campaign_blurb %></span>
   </:subtitle>
 </.header>
+
+<% sorted_tasks = Enum.sort_by(@tasks, & &1.id) %>
 <!-- Desktop Table of tasks -->
 <section class="hidden md:block">
-  <.table id="tasks" rows={@tasks}>
+  <.table id="tasks" rows={sorted_tasks}>
     <:col :let={_task} label="Pickup time">
       <%= pickup_window(@campaign) %>
     </:col>
@@ -25,13 +27,18 @@
     <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
       <.truncated_riders_notes note={task.rider_notes || "--"} /></:col>
     <:action :let={task}>
-      <.signup_button id="signup-btn-desktop" campaign={@campaign} task={task} current_rider_id={@current_rider_id} />
+      <.signup_button
+        id="signup-btn-desktop"
+        campaign={@campaign}
+        task={task}
+        current_rider_id={@current_rider_id}
+      />
     </:action>
   </.table>
 </section>
 <!-- Mobile list of tasks -->
 <ul class="flex flex-col text-xs md:hidden">
-  <li :for={t <- @tasks} class="w-full mb-8">
+  <li :for={t <- sorted_tasks} class="w-full mb-8">
     <div class="flex px-4 py-3 font-bold bg-slate-200 justify-between">
       <span><%= t.dropoff_name %></span>
       <span>Pickup: <%= pickup_window(@campaign) %></span>
@@ -55,7 +62,12 @@
       </div>
 
       <div class="flex flex-col justify-center px-4 py-2 border-b-2">
-        <.signup_button id="signup-btn-mobile" campaign={@campaign} task={t} current_rider_id={@current_rider_id} />
+        <.signup_button
+          id="signup-btn-mobile"
+          campaign={@campaign}
+          task={t}
+          current_rider_id={@current_rider_id}
+        />
       </div>
     </div>
   </li>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -10,10 +10,9 @@
   </:subtitle>
 </.header>
 
-<% sorted_tasks = Enum.sort_by(@tasks, & &1.id) %>
 <!-- Desktop Table of tasks -->
 <section class="hidden md:block">
-  <.table id="tasks" rows={sorted_tasks}>
+  <.table id="tasks" rows={@tasks}>
     <:col :let={_task} label="Pickup time">
       <%= pickup_window(@campaign) %>
     </:col>
@@ -38,7 +37,7 @@
 </section>
 <!-- Mobile list of tasks -->
 <ul class="flex flex-col text-xs md:hidden">
-  <li :for={t <- sorted_tasks} class="w-full mb-8">
+  <li :for={t <- @tasks} class="w-full mb-8">
     <div class="flex px-4 py-3 font-bold bg-slate-200 justify-between">
       <span><%= t.dropoff_name %></span>
       <span>Pickup: <%= pickup_window(@campaign) %></span>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -25,7 +25,7 @@
     <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
       <.truncated_riders_notes note={task.rider_notes || "--"} /></:col>
     <:action :let={task}>
-      <.signup_button campaign={@campaign} task={task} current_rider_id={@current_rider_id} />
+      <.signup_button id="signup-btn-desktop" campaign={@campaign} task={task} current_rider_id={@current_rider_id} />
     </:action>
   </.table>
 </section>
@@ -55,7 +55,7 @@
       </div>
 
       <div class="flex flex-col justify-center px-4 py-2 border-b-2">
-        <.signup_button campaign={@campaign} task={t} current_rider_id={@current_rider_id} />
+        <.signup_button id="signup-btn-mobile" campaign={@campaign} task={t} current_rider_id={@current_rider_id} />
       </div>
     </div>
   </li>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -1,56 +1,62 @@
-<.header>
-  <%= @campaign.program.name %> - <%= campaign_date(@campaign) %>
+<.header class="text-center mt-4 mb-8 md:text-left">
+  <div class="hidden md:flex">
+    <%= @campaign.program.name %> - <%= campaign_date(@campaign) %>
+  </div>
+  <div class="text-xl flex flex-col mb-4 md:hidden"><%= @campaign.program.name %></div>
+  <div class="text-sm mt-2 md:hidden">Deliveries for <%= campaign_date(@campaign) %></div>
   <:subtitle>
-    <span class="font-bold"><%= @campaign.location.address %></span>
-    <span :if={@campaign.program.campaign_blurb}>
-      - <%= @campaign.program.campaign_blurb %>
-    </span>
+    <span class="text-sm font-bold">Pickup: <%= @campaign.location.address %></span>
+    <span :if={@campaign.program.campaign_blurb}>- <%= @campaign.program.campaign_blurb %></span>
   </:subtitle>
 </.header>
-
-<section>
+<!-- Desktop Table of tasks -->
+<section class="hidden md:block">
   <.table id="tasks" rows={@tasks}>
     <:col :let={_task} label="Pickup time">
       <%= pickup_window(@campaign) %>
     </:col>
     <:col :let={task} label="Delivery Size">
-      <.get_delivery_size task={task}/>
+      <.get_delivery_size task={task} />
     </:col>
     <:col :let={task} label="Recipient"><%= task.dropoff_name %></:col>
-    <:col :let={task} label="Dropoff Neighbourhood"><%= Locations.neighborhood(task.dropoff_location) %></:col>
-    <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
-      <.truncated_riders_notes note={task.rider_notes || "--"}/>
+    <:col :let={task} label="Dropoff Neighbourhood">
+      <%= Locations.neighborhood(task.dropoff_location) %>
     </:col>
+    <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
+      <.truncated_riders_notes note={task.rider_notes || "--"} /></:col>
     <:action :let={task}>
-      <%= if task.assigned_rider do %>
-        <span
-          :if={task.assigned_rider.id != @current_rider_id}
-          class="mr-2"> <%= split_first_name(task.assigned_rider.name) %></span>
-
-        <.button
-          :if={task.assigned_rider.id == @current_rider_id}
-          id={"task-#{task.id}"}
-          phx-click={JS.push("unassign_task", value: %{task_id: task.id})}
-          color={:red}
-          size={:xsmall}
-          class="w-28">
-          Unassign me
-        </.button>
-
-      <% end %>
-
-      <%= if is_nil(task.assigned_rider) do %>
-        <.button
-          phx-click={JS.push("signup_rider", value: %{task_id: task.id, rider_id: @current_rider_id})}
-          id={"task-#{task.id}"}
-          color={:primary}
-          size={:xsmall}
-          class="w-28"
-          >
-          Sign up
-        </.button>
-
-      <% end %>
+      <.signup_button campaign={@campaign} task={task} current_rider_id={@current_rider_id} />
     </:action>
   </.table>
 </section>
+<!-- Mobile list of tasks -->
+<ul class="flex flex-col text-xs md:hidden">
+  <li :for={t <- @tasks} class="w-full mb-8">
+    <div class="flex px-4 py-3 font-bold bg-slate-200 justify-between">
+      <span><%= t.dropoff_name %></span>
+      <span>Pickup: <%= pickup_window(@campaign) %></span>
+    </div>
+    <div class="flex flex-col bg-white shadow">
+      <div class="flex py-2 border-b p-4 items-center">
+        <span class="pr-2 ">Delivery size:</span>
+        <span class="italic">
+          <.get_delivery_size task={t} />
+        </span>
+      </div>
+
+      <div class="flex flex-col justify-center px-4 py-2 border-b">
+        <span>Dropoff Neighbourhood:</span>
+        <span><%= Locations.neighborhood(t.dropoff_location) %></span>
+      </div>
+
+      <div :if={t.rider_notes} class="flex flex-col justify-center px-4 py-2 border-b-2">
+        <span>Notes:</span>
+        <span><%= t.rider_notes %></span>
+      </div>
+
+      <div class="flex flex-col justify-center px-4 py-2 border-b-2">
+        <.signup_button campaign={@campaign} task={t} current_rider_id={@current_rider_id} />
+      </div>
+    </div>
+  </li>
+</ul>


### PR DESCRIPTION
This PR is a rider-portal focused set of changes that makes the campaign sign-up delivery list and campaign sign-up task list more mobile-friendly.

For the Rider Task List, I left the desktop design to continue using a table-based layout and chose to render an unordered list for mobile. This means that the markup shows up twice in the DOM and is hidden by Tailwind. Optionally, I could remove the table entirely on desktop to reduce repetition.

On the implementation side, this does some small refactoring to tidy up how the sign up for campaign button renders as there are lots of permutations based on the rider's state as well as the campaign state.

Please review the below video to see a basic overview.

Commits are fairly atomic and go into more detail as necessary.

https://github.com/bikebrigade/dispatch/assets/12987958/3d7a97a6-dd4b-4200-aa3e-14eed36f3c47


