### PR TITLE
Migrate: campaign_riders to have rider_signed_up.

### DIFF
--- a/lib/bike_brigade/delivery/campaign_rider.ex
+++ b/lib/bike_brigade/delivery/campaign_rider.ex
@@ -15,6 +15,7 @@ defmodule BikeBrigade.Delivery.CampaignRider do
     field :pickup_window, :string
     field :enter_building, :boolean, default: false
     field :token, :string
+    field :rider_signed_up, :boolean, default: false
 
     timestamps()
   end
@@ -27,7 +28,8 @@ defmodule BikeBrigade.Delivery.CampaignRider do
       :rider_capacity,
       :notes,
       :pickup_window,
-      :enter_building
+      :enter_building,
+      :rider_signed_up
     ])
     |> maybe_gen_token()
     # TODO this required validation for :campaign_id may be not needed

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -121,7 +121,8 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
       "pickup_window" => pickup_window(campaign),
       "enter_building" => true,
       "campaign_id" => campaign.id,
-      "rider_id" => rider_id
+      "rider_id" => rider_id,
+      "rider_signed_up" => true
     }
 
     case Delivery.create_campaign_rider(attrs) do

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -14,19 +14,18 @@
       <%= pickup_window(@campaign) %>
     </:col>
     <:col :let={task} label="Delivery Size">
-      <.get_delivery_size task={task} />
+      <.get_delivery_size task={task}/>
     </:col>
     <:col :let={task} label="Recipient"><%= task.dropoff_name %></:col>
-    <:col :let={task} label="Dropoff Neighbourhood">
-      <%= Locations.neighborhood(task.dropoff_location) %>
-    </:col>
+    <:col :let={task} label="Dropoff Neighbourhood"><%= Locations.neighborhood(task.dropoff_location) %></:col>
     <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
-      <.truncated_riders_notes note={task.rider_notes || "--"} /></:col>
+      <.truncated_riders_notes note={task.rider_notes || "--"}/>
+    </:col>
     <:action :let={task}>
       <%= if task.assigned_rider do %>
-        <span :if={task.assigned_rider.id != @current_rider_id} class="mr-2">
-          <%= split_first_name(task.assigned_rider.name) %>
-        </span>
+        <span
+          :if={task.assigned_rider.id != @current_rider_id}
+          class="mr-2"> <%= split_first_name(task.assigned_rider.name) %></span>
 
         <.button
           :if={task.assigned_rider.id == @current_rider_id}
@@ -34,24 +33,23 @@
           phx-click={JS.push("unassign_task", value: %{task_id: task.id})}
           color={:red}
           size={:xsmall}
-          class="w-28"
-        >
+          class="w-28">
           Unassign me
         </.button>
+
       <% end %>
 
       <%= if is_nil(task.assigned_rider) do %>
         <.button
-          phx-click={
-            JS.push("signup_rider", value: %{task_id: task.id, rider_id: @current_rider_id})
-          }
+          phx-click={JS.push("signup_rider", value: %{task_id: task.id, rider_id: @current_rider_id})}
           id={"task-#{task.id}"}
           color={:primary}
           size={:xsmall}
           class="w-28"
-        >
+          >
           Sign up
         </.button>
+
       <% end %>
     </:action>
   </.table>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -14,18 +14,19 @@
       <%= pickup_window(@campaign) %>
     </:col>
     <:col :let={task} label="Delivery Size">
-      <.get_delivery_size task={task}/>
+      <.get_delivery_size task={task} />
     </:col>
     <:col :let={task} label="Recipient"><%= task.dropoff_name %></:col>
-    <:col :let={task} label="Dropoff Neighbourhood"><%= Locations.neighborhood(task.dropoff_location) %></:col>
-    <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
-      <.truncated_riders_notes note={task.rider_notes || "--"}/>
+    <:col :let={task} label="Dropoff Neighbourhood">
+      <%= Locations.neighborhood(task.dropoff_location) %>
     </:col>
+    <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
+      <.truncated_riders_notes note={task.rider_notes || "--"} /></:col>
     <:action :let={task}>
       <%= if task.assigned_rider do %>
-        <span
-          :if={task.assigned_rider.id != @current_rider_id}
-          class="mr-2"> <%= split_first_name(task.assigned_rider.name) %></span>
+        <span :if={task.assigned_rider.id != @current_rider_id} class="mr-2">
+          <%= split_first_name(task.assigned_rider.name) %>
+        </span>
 
         <.button
           :if={task.assigned_rider.id == @current_rider_id}
@@ -33,23 +34,24 @@
           phx-click={JS.push("unassign_task", value: %{task_id: task.id})}
           color={:red}
           size={:xsmall}
-          class="w-28">
+          class="w-28"
+        >
           Unassign me
         </.button>
-
       <% end %>
 
       <%= if is_nil(task.assigned_rider) do %>
         <.button
-          phx-click={JS.push("signup_rider", value: %{task_id: task.id, rider_id: @current_rider_id})}
+          phx-click={
+            JS.push("signup_rider", value: %{task_id: task.id, rider_id: @current_rider_id})
+          }
           id={"task-#{task.id}"}
           color={:primary}
           size={:xsmall}
           class="w-28"
-          >
+        >
           Sign up
         </.button>
-
       <% end %>
     </:action>
   </.table>

--- a/priv/repo/migrations/20240314201721_add_campaigns_riders_rider_signed_up_flag.exs
+++ b/priv/repo/migrations/20240314201721_add_campaigns_riders_rider_signed_up_flag.exs
@@ -1,0 +1,8 @@
+defmodule BikeBrigade.Repo.Migrations.AddCampaignsRidersRiderSignedUpFlag do
+  use Ecto.Migration
+  def change do
+    alter table(:campaigns_riders) do
+      add :rider_signed_up, :boolean, default: false
+    end
+  end
+end


### PR DESCRIPTION
## Why?

We want to be able to discern when a rider themself is responsible for signing up for a campaign versus a dispatcher signing up a rider. This way we'll be able to better create reports and see the effectiveness of the rider portal.

## Notes

I was trying to think of how I could test this on the frontend, but couldn't think of any ways that the ui changes as a result of this addition.  I could add tests to the `delivery.ex` context I suppose?

