### PR TITLE
Fix overflowing tag list

### DIFF
--- a/lib/bike_brigade_web/live/rider_live/show.html.heex
+++ b/lib/bike_brigade_web/live/rider_live/show.html.heex
@@ -104,8 +104,9 @@
           <%= if Enum.empty?(@rider.tags) do %>
             No tags
           <% else %>
-            <span class="inline-flex">
-              <%= for tag <- @rider.tags do %>
+            <span class="inline-flex flex-wrap">
+              <%= for tag <- List.duplicate(hd(@rider.tags), 100) do %>
+
                 <span class="before:content-[','] first:before:content-['']">
                   <.link navigate={~p"/riders?#{%{filters: ["tag:#{tag.name}"]}}"} class="link">
                     <%= tag.name %>


### PR DESCRIPTION
Go from 
<img width="985" alt="CleanShot 2024-03-20 at 17 41 13@2x" src="https://github.com/bikebrigade/dispatch/assets/34720/54df8dae-fa18-42f6-8d0b-78895a6a210f">

to

<img width="901" alt="CleanShot 2024-03-20 at 17 42 44@2x" src="https://github.com/bikebrigade/dispatch/assets/34720/c235cca7-a61c-4e53-87cc-acf01a89bc98">


