### PR TITLE
Add show/hide button to the leaderboard next to your name

### DIFF
--- a/lib/bike_brigade_web/live/stats_live/leaderboard.ex
+++ b/lib/bike_brigade_web/live/stats_live/leaderboard.ex
@@ -195,10 +195,27 @@ defmodule BikeBrigadeWeb.StatsLive.Leaderboard do
 
     class = if is_current_rider, do: "bg-yellow-200 p-1", else: "p-1"
 
-    assigns = assign(assigns, name: name, class: class)
+    assigns =
+      assign(assigns,
+        name: name,
+        class: class,
+        is_anonymous: is_anonymous,
+        is_current_rider: is_current_rider
+      )
 
     ~H"""
-    <span class={@class}><%= @name %></span>
+    <div class="flex flex-col sm:flex-row">
+      <span class={@class}><%= @name %></span>
+      <.button
+        :if={is_current_rider}
+        size={:xsmall}
+        color={:secondary}
+        class="mt-1 ml-0 sm:ml-1 sm:mt-0"
+        phx-click="toggle_rider_anon"
+      >
+        <%= if @is_anonymous, do: "Show", else: "Hide" %> me
+      </.button>
+    </div>
     """
   end
 end


### PR DESCRIPTION
Based on Darlene's feedback I added a button next to your name to show/hide yourself

<img width="984" alt="CleanShot 2024-03-26 at 11 36 36@2x" src="https://github.com/bikebrigade/dispatch/assets/34720/35663cba-69c3-428c-9727-f19d21cff8c5">

<img width="397" alt="CleanShot 2024-03-26 at 11 36 29@2x" src="https://github.com/bikebrigade/dispatch/assets/34720/1e75e2c4-bf84-4f0b-bd90-2e6ef41c510f">
