### PR TITLE
Fix: hide assigned tasks if campaign in past on rider signup page.

### DIFF
--- a/lib/bike_brigade_web/live/campaign_signup_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/index.ex
@@ -127,7 +127,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
           {"text-gray-600", "N/A"}
 
         campaign_in_past(assigns.campaign) ->
-          {"text-gray-600", "N/A"}
+          {"text-gray-600", "Campaign over"}
 
         assigns.total_tasks - assigns.filled_tasks == 0 ->
           {"text-gray-600", "Fully Assigned"}

--- a/lib/bike_brigade_web/live/campaign_signup_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/index.ex
@@ -122,13 +122,18 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
 
   defp tasks_filled_text(assigns) do
     {class, copy} =
-      if assigns.filled_tasks == nil do
-        {"", "N/A"}
-      else
-        case assigns.total_tasks - assigns.filled_tasks do
-          0 -> {"text-gray-600", "Fully Assigned"}
-          _ -> {"text-red-400", "#{assigns.total_tasks - assigns.filled_tasks} Available"}
-        end
+      cond do
+        assigns.filled_tasks == nil ->
+          {"text-gray-600", "N/A"}
+
+        campaign_in_past(assigns.campaign) ->
+          {"text-gray-600", "N/A"}
+
+        assigns.total_tasks - assigns.filled_tasks == 0 ->
+          {"text-gray-600", "Fully Assigned"}
+
+        true ->
+          {"text-red-400", "#{assigns.total_tasks - assigns.filled_tasks} Available"}
       end
 
     assigns =

--- a/test/bike_brigade_web/live/rider_home_live_test.exs
+++ b/test/bike_brigade_web/live/rider_home_live_test.exs
@@ -77,7 +77,7 @@ defmodule BikeBrigadeWeb.RiderHomeLiveTest do
       # assert that only 2 campaigns - the ones with unfilled tasks are showing up.
       assert Floki.parse_document!(html)
              |> Floki.find(".campaign-item")
-             |> Enum.count() == 3
+             |> Enum.count() == 2
     end
 
     test "it shows rider's itinerary of deliveries for today, with a sign up button", ctx do


### PR DESCRIPTION
Fixes #306 . 

**Before/After:**

![CleanShot 2024-04-10 at 14 33 25@2x](https://github.com/bikebrigade/dispatch/assets/12987958/3990bb2e-fd51-4905-ac45-edded9b44f08)
