### PR TITLE
Fix: Display "campaign over" if campaign in past

### DIFF
--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -254,6 +254,17 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
           Sign up
         </.button>
       <% end %>
+
+      <%= if campaign_in_past(@campaign) do %>
+        <.button
+          color={:secondary}
+          id={"#{@id}-task-over-#{@task.id}"}
+          size={:xsmall}
+          class="w-full md:w-28 cursor-not-allowed bg-neutral-100 text-neutral-800"
+        >
+          Campaign over
+        </.button>
+      <% end %>
     </div>
     """
   end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -50,7 +50,7 @@
         </span>
       </div>
 
-      <div class="flex flex-col justify-center px-4 py-2 border-b">
+      <div class="flex px-4 py-2 items-start border-b space-x-2">
         <span>Dropoff Neighbourhood:</span>
         <span><%= Locations.neighborhood(t.dropoff_location) %></span>
       </div>


### PR DESCRIPTION
Fixes #312 

### Changes
- Screenshot demonstrates showing a task a rider can signup for in the present, then moving the campaign into the past, then showing that the "campaign is over".
- Also updates the address to be one line.

https://github.com/bikebrigade/dispatch/assets/12987958/82305681-61b5-4e76-94ba-6315a5a6bb60

