### PR TITLE
Enable login for all newly created riders

### DIFF
--- a/lib/bike_brigade/riders.ex
+++ b/lib/bike_brigade/riders.ex
@@ -7,6 +7,7 @@ defmodule BikeBrigade.Riders do
   alias BikeBrigade.Repo
   alias BikeBrigade.LocalizedDateTime
 
+  alias BikeBrigade.Accounts
   alias BikeBrigade.Riders.{Rider, Tag}
   alias BikeBrigade.Delivery.{Campaign, CampaignRider}
 
@@ -185,8 +186,21 @@ defmodule BikeBrigade.Riders do
     |> broadcast(:rider_created)
   end
 
-  # TODO: make it pretty
+  @doc """
+  Create a rider with the ability to log in (an associated User)
+  """
 
+  def create_rider_with_user(attrs \\ %{}, opts \\ []) do
+    with {:ok, rider} <- create_rider(attrs, opts),
+         {:ok, user} <- Accounts.create_user_for_rider(rider) do
+      {:ok, rider}
+    else
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  # TODO: make it pretty
+  # TODO This may not be needed, i think it's only used when creating riders from a form input which we don't seem to do?
   def create_rider_with_tags(attrs \\ %{}, tags \\ [], opts \\ []) do
     %Rider{}
     |> Rider.changeset(attrs)

--- a/lib/bike_brigade/tasks/mailchimp_importer.ex
+++ b/lib/bike_brigade/tasks/mailchimp_importer.ex
@@ -1,6 +1,7 @@
 defmodule BikeBrigade.Tasks.MailchimpImporter do
   import Ecto.Query, warn: false
   import BikeBrigade.Utils, only: [get_config: 1, with_default: 2]
+  alias BikeBrigade.Accounts
   alias BikeBrigade.Repo
   alias BikeBrigade.Locations.Location
   alias BikeBrigade.Tasks.Importer
@@ -80,7 +81,7 @@ defmodule BikeBrigade.Tasks.MailchimpImporter do
         Riders.update_rider(rider, rider_attrs)
 
       nil ->
-        Riders.create_rider(rider_attrs)
+        Riders.create_rider_with_user(rider_attrs)
     end
   end
 

--- a/lib/bike_brigade_web/live/rider_live/form_component.ex
+++ b/lib/bike_brigade_web/live/rider_live/form_component.ex
@@ -154,6 +154,7 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
     save_rider_edit_impl(socket, rider_form_params)
   end
 
+  # TODO: this can probably be deleted: we don't really create riders from the form?
   defp save_rider(socket, :new, rider_params) do
     case Riders.create_rider_with_tags(rider_params, rider_params["tags"]) do
       {:ok, _rider} ->

--- a/lib/bike_brigade_web/live/rider_live/form_component.ex
+++ b/lib/bike_brigade_web/live/rider_live/form_component.ex
@@ -155,6 +155,7 @@ defmodule BikeBrigadeWeb.RiderLive.FormComponent do
   end
 
   # TODO: this can probably be deleted: we don't really create riders from the form?
+  # https://github.com/bikebrigade/dispatch/issues/321
   defp save_rider(socket, :new, rider_params) do
     case Riders.create_rider_with_tags(rider_params, rider_params["tags"]) do
       {:ok, _rider} ->

--- a/test/bike_brigade/riders_test.exs
+++ b/test/bike_brigade/riders_test.exs
@@ -1,6 +1,8 @@
 defmodule BikeBrigade.RidersTest do
   use BikeBrigade.DataCase
 
+  alias BikeBrigade.Utils
+  alias BikeBrigade.LocalizedDateTime
   alias BikeBrigade.Riders
   alias BikeBrigade.Riders.Rider
 
@@ -8,6 +10,32 @@ defmodule BikeBrigade.RidersTest do
   alias BikeBrigade.Accounts.User
   alias BikeBrigade.Locations.Location
   alias BikeBrigade.Messaging.SmsMessage
+
+  describe "creating riders" do
+    test "creates a rider with a user" do
+      location = BikeBrigade.Repo.Seeds.Toronto.random_location()
+
+      assert {:ok, rider} =
+               Riders.create_rider_with_user(%{
+                 address: location.address,
+                 capacity: Utils.random_enum(Riders.Rider.CapacityEnum),
+                 email: Faker.Internet.email(),
+                 location: location,
+                 max_distance: 20,
+                 name: "Test Rider",
+                 phone: "+16474567890",
+                 postal: location.postal,
+                 pronouns: Enum.random(~w(He/Him She/Her They/Them)),
+                 signed_up_on: LocalizedDateTime.now()
+               })
+
+      assert rider.name == "Test Rider"
+      assert rider.phone == "+16474567890"
+
+      user = Accounts.get_user_by_phone("+16474567890")
+      assert user.rider_id == rider.id
+    end
+  end
 
   describe "removing riders" do
     setup do
@@ -44,7 +72,6 @@ defmodule BikeBrigade.RidersTest do
 
       {:ok, rider} = rider |> Riders.update_rider_with_tags(%{}, ["tag1", "tag2"])
       assert Enum.count(rider.tags) == 2
-
 
       {:ok, rider} = rider |> Riders.update_rider_with_tags(%{}, [])
       assert Enum.count(rider.tags) == 0


### PR DESCRIPTION
This PR let's new riders log in automatically after they are created

Closes #308 

For the existing riders I'm going to manually create accounts for them in the IEx shell