### PR TITLE
Fix port and scheme for production

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -136,7 +136,7 @@ case config_env() do
     case app_env do
       :production ->
         config :bike_brigade, BikeBrigadeWeb.Endpoint,
-          url: [host: "dispatch.bikebrigade.ca", port: 80]
+          url: [host: "dispatch.bikebrigade.ca", port: 443, scheme: "https"]
 
         config :bike_brigade, BikeBrigade.Messaging.Slack.Operations,
           channel_id: "C016VGHETS4",


### PR DESCRIPTION
Before all our internal links used http:// and then we had ssl_rewrite come in. This caused problems for some people on older phones etc

