### PR TITLE
Fix: make dispatcher mcgee indeed a dispatcher.

### DIFF
--- a/priv/repo/seeds/seeder.ex
+++ b/priv/repo/seeds/seeder.ex
@@ -14,7 +14,8 @@ defmodule BikeBrigade.Repo.Seeds.Seeder do
       Accounts.create_user_as_admin(%{
         name: "Dispatcher McGee",
         phone: "647-555-5555",
-        email: "dispatcher@example.com"
+        email: "dispatcher@example.com",
+        is_dispatcher: true
       })
 
     user


### PR DESCRIPTION
In setting up the repo from fresh, I noted that on a clean DB, logging in tries to route you to /home - thinking that the user is a user. This is because the seeded dispatcher does not have is_dispatcher set to true.