### PR TITLE
Fix: only show urgent riders from now -> 48 hours

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -180,19 +180,18 @@ defmodule BikeBrigade.Delivery do
 
 
   @doc """
-    Gets campaigns that are happening today and have unassigned tasks.
+    Gets campaigns that are happening between now and 48 hours from now, and have unassigned tasks.
     Used on the rider's home page to let riders know about campaigns that could use the help.
   """
   def list_urgent_campaigns() do
-    today = LocalizedDateTime.today()
-    start_of_today = LocalizedDateTime.new!(today, ~T[00:00:00])
-    end_of_tomorrow = Date.add(today, 1) |> LocalizedDateTime.new!(~T[23:59:59])
+    now = LocalizedDateTime.now()
+    forty_eight_hours_from_now = DateTime.add(now, 48, :hour)
 
     query =
       from c in Campaign,
         distinct: [asc: c.id],
         join: t in assoc(c, :tasks),
-        where: c.delivery_start <= ^end_of_tomorrow and c.delivery_start >= ^start_of_today and is_nil(t.assigned_rider_id),
+        where: c.delivery_start <= ^forty_eight_hours_from_now and c.delivery_start >= ^now and is_nil(t.assigned_rider_id),
         select: c
 
     Repo.all(query)

--- a/test/bike_brigade_web/live/rider_home_live_test.exs
+++ b/test/bike_brigade_web/live/rider_home_live_test.exs
@@ -86,7 +86,7 @@ defmodule BikeBrigadeWeb.RiderHomeLiveTest do
       # assert that only 2 campaigns - the ones with unfilled tasks are showing up.
       assert Floki.parse_document!(html)
              |> Floki.find(".campaign-item")
-             |> Enum.count() == 2
+             |> Enum.count() == 3
     end
 
     test "it shows rider's itinerary of deliveries for today, with a sign up button", ctx do

--- a/test/bike_brigade_web/live/rider_home_live_test.exs
+++ b/test/bike_brigade_web/live/rider_home_live_test.exs
@@ -6,10 +6,11 @@ defmodule BikeBrigadeWeb.RiderHomeLiveTest do
 
   defp make_campaign(program_id, opts \\ []) do
     start_offset = Keyword.get(opts, :start_offset, 0)
+    offset_type = Keyword.get(opts, :offset_type, :day)
     fixture(:campaign, %{
       program_id: program_id,
-      delivery_start: LocalizedDateTime.now() |> DateTime.add(start_offset, :day),
-      delivery_end: LocalizedDateTime.now() |> DateTime.add(start_offset, :day) |> DateTime.add(1, :hour),
+      delivery_start: LocalizedDateTime.now() |> DateTime.add(start_offset, offset_type),
+      delivery_end: LocalizedDateTime.now() |> DateTime.add(start_offset, offset_type) |> DateTime.add(1, :hour),
     })
   end
 
@@ -24,6 +25,12 @@ defmodule BikeBrigadeWeb.RiderHomeLiveTest do
       campaign = make_campaign(program.id)
       campaign2 = make_campaign(program2.id)
       campaign3 = make_campaign(program2.id, start_offset: 1)
+
+      # campaign4 and campaign_in_50_hours  are used to test that the
+      # CTA for urgent riders only shows from `now` to `now + 48 hours`
+      campaign4 = make_campaign(program2.id, start_offset: -1, offset_type: :hour)
+      campaign_in_50_hours = make_campaign(program2.id, start_offset: 50, offset_type: :hour)
+
       campaign_past_1 = make_campaign(program.id, start_offset: -7)
       campaign_past_2 = make_campaign(program.id, start_offset: -7)
 
@@ -32,6 +39,8 @@ defmodule BikeBrigadeWeb.RiderHomeLiveTest do
       fixture(:task, %{campaign: campaign, rider: nil})
       fixture(:task, %{campaign: campaign2, rider: nil})
       fixture(:task, %{campaign: campaign3, rider: nil})
+      fixture(:task, %{campaign: campaign4, rider: nil})
+      fixture(:task, %{campaign: campaign_in_50_hours, rider: nil})
 
       # create tasks for campaigns in the last seven days for the stats feature.
       for _r <- 1..7, do: fixture(:task, %{campaign: campaign_past_1, rider: res.rider})

--- a/test/bike_brigade_web/live/rider_home_live_test.exs
+++ b/test/bike_brigade_web/live/rider_home_live_test.exs
@@ -82,11 +82,12 @@ defmodule BikeBrigadeWeb.RiderHomeLiveTest do
 
       assert live |> has_element?("#campaign-#{ctx.campaign.id}")
       assert live |> has_element?("#campaign-#{ctx.campaign2.id}")
+      assert live |> has_element?("#campaign-#{ctx.campaign3.id}")
 
       # assert that only 2 campaigns - the ones with unfilled tasks are showing up.
       assert Floki.parse_document!(html)
              |> Floki.find(".campaign-item")
-             |> Enum.count() == 2
+             |> Enum.count() == 3
     end
 
     test "it shows rider's itinerary of deliveries for today, with a sign up button", ctx do

--- a/test/bike_brigade_web/live/rider_home_live_test.exs
+++ b/test/bike_brigade_web/live/rider_home_live_test.exs
@@ -86,7 +86,7 @@ defmodule BikeBrigadeWeb.RiderHomeLiveTest do
       # assert that only 2 campaigns - the ones with unfilled tasks are showing up.
       assert Floki.parse_document!(html)
              |> Floki.find(".campaign-item")
-             |> Enum.count() == 3
+             |> Enum.count() == 2
     end
 
     test "it shows rider's itinerary of deliveries for today, with a sign up button", ctx do


### PR DESCRIPTION
Originally, we were listing deliveries from the top of the day until 48 hours / the end of the next day. Now, we list deliveries that are from now till 48 hours from now.

Fixes #309 