### PR TITLE
Add concept of `private` campaigns

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -151,6 +151,9 @@ defmodule BikeBrigade.Delivery do
     # (such as when we need to display campaigns that urgently need a rider)
     campaign_ids = Keyword.get(opts, :campaign_ids, nil)
 
+    public = Keyword.get(opts, :public, nil)
+
+
     query =
       from c in Campaign,
         as: :campaign,
@@ -170,6 +173,13 @@ defmodule BikeBrigade.Delivery do
     query = if campaign_ids do
       query
       |> where([campaign: c], c.id in ^campaign_ids)
+    else
+      query
+    end
+
+    query = if !is_nil(public)  do
+      query
+      |> where([campaign: c], c.public == ^public)
     else
       query
     end

--- a/lib/bike_brigade/delivery/campaign.ex
+++ b/lib/bike_brigade/delivery/campaign.ex
@@ -21,7 +21,8 @@ defmodule BikeBrigade.Delivery.Campaign do
     :details,
     :rider_spreadsheet_id,
     :rider_spreadsheet_layout,
-    :program_id
+    :program_id,
+    :public,
   ]
 
   @embedded_fields [
@@ -32,6 +33,9 @@ defmodule BikeBrigade.Delivery.Campaign do
     field :delivery_start, :utc_datetime
     field :delivery_end, :utc_datetime
     field :details, :string
+
+    # Make campaigns private for now by default
+    field :public, :boolean, default: false
 
     # TODO remove
     field :rider_spreadsheet_id, :string

--- a/lib/bike_brigade_web/live/campaign_live/form_component.ex
+++ b/lib/bike_brigade_web/live/campaign_live/form_component.ex
@@ -21,6 +21,7 @@ defmodule BikeBrigadeWeb.CampaignLive.FormComponent do
       field :task_spreadsheet_url, :string
       field :rider_spreadsheet_url, :string
       field :rider_spreadsheet_layout, :string
+      field :public, :boolean
 
       belongs_to :location, Location, on_replace: :update
       belongs_to :program, Program
@@ -35,6 +36,7 @@ defmodule BikeBrigadeWeb.CampaignLive.FormComponent do
         :task_spreadsheet_url,
         :rider_spreadsheet_url,
         :rider_spreadsheet_layout,
+        :public,
         :program_id
       ])
       |> cast_assoc(:location)
@@ -47,6 +49,7 @@ defmodule BikeBrigadeWeb.CampaignLive.FormComponent do
         delivery_date: LocalizedDateTime.to_date(campaign.delivery_start),
         start_time: LocalizedDateTime.to_time(campaign.delivery_start),
         end_time: LocalizedDateTime.to_time(campaign.delivery_end),
+        public: campaign.public,
         location: campaign.location,
         rider_spreadsheet_layout: campaign.rider_spreadsheet_layout
       }
@@ -58,6 +61,7 @@ defmodule BikeBrigadeWeb.CampaignLive.FormComponent do
         delivery_start:
           LocalizedDateTime.new!(campaign_form.delivery_date, campaign_form.start_time),
         delivery_end: LocalizedDateTime.new!(campaign_form.delivery_date, campaign_form.end_time),
+        public: campaign_form.public,
         location: Map.from_struct(campaign_form.location),
         rider_spreadsheet_layout: campaign_form.rider_spreadsheet_layout
       }

--- a/lib/bike_brigade_web/live/campaign_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/form_component.html.heex
@@ -26,24 +26,32 @@
     />
 
     <.input
-      type="text"
-      field={{f, :task_spreadsheet_url}}
-      label="Delivery Spreadsheet"
-      help_text="Link to a Google sheet"
-    />
-    <.input
-      type="text"
-      field={{f, :rider_spreadsheet_url}}
-      label="Rider Spreadsheet"
-      help_text="Link to a Google sheet"
-    />
-    <.input
-      type="select"
-      field={{f, :rider_spreadsheet_layout}}
-      options={["Not Foodshare": :non_foodshare, Foodshare: :foodshare]}
-      label="Program"
+      type="checkbox"
+      field={{f, :public}}
+      label="Public"
+      help_text="Let riders sign up for this campaign through dispatch"
     />
 
+    <fieldset class="pt-4 space-y-4 border-t border-gray-900/10">
+      <.input
+        type="text"
+        field={{f, :task_spreadsheet_url}}
+        label="Delivery Spreadsheet"
+        help_text="Link to a Google sheet"
+      />
+      <.input
+        type="text"
+        field={{f, :rider_spreadsheet_url}}
+        label="Rider Spreadsheet"
+        help_text="Link to a Google sheet"
+      />
+      <.input
+        type="select"
+        field={{f, :rider_spreadsheet_layout}}
+        options={["Not Foodshare": :non_foodshare, Foodshare: :foodshare]}
+        label="Spreadsheet Layout"
+      />
+    </fieldset>
     <:actions>
       <.button type="submit" phx-disable-with="Saving...">Save</.button>
     </:actions>

--- a/lib/bike_brigade_web/live/campaign_live/index.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/index.html.heex
@@ -23,7 +23,7 @@
   <.live_component
     module={BikeBrigadeWeb.CampaignLive.DuplicateCampaignComponent}
     id={:duplicate}
-      title={@page_title}
+    title={@page_title}
     action={@live_action}
     campaign={@campaign}
     navigate={~p"/campaigns?current_week=#{@current_week}"}
@@ -87,6 +87,12 @@
                     data-test-group="campaign-name"
                   >
                     <%= name(c) %>
+                    <span
+                      :if={!c.public}
+                      class="inline-flex items-center px-2 py-1 ml-1 text-xs font-medium text-pink-700 rounded-md bg-pink-50 ring-1 ring-inset ring-pink-700/10"
+                    >
+                      Private
+                    </span>
                   </.link>
                 </div>
                 <div class="flex-shrink-0 space-y-1 md:space-y-0 md:space-x-2 md:flex">

--- a/lib/bike_brigade_web/live/campaign_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/show.html.heex
@@ -55,11 +55,11 @@
       </ul>
     </div>
 
-    <div class="md:flex relative inline-block dropdown">
+    <div class="relative inline-block md:flex dropdown">
       <.button
         :if={Enum.count(@riders) > 0}
         patch={~p"/campaigns/#{@campaign}/messaging/riders/"}
-        class="btn w-40 my-3 mr-3"
+        class="w-40 my-3 mr-3 btn"
       >
         Rider Messaging
       </.button>
@@ -81,6 +81,12 @@
         <.date date={campaign_date(@campaign)} />
         <h1 class="flex items-center pl-2 text-lg font-medium leading-6 text-gray-900">
           <%= name(@campaign) %>
+          <span
+            :if={!@campaign.public}
+            class="inline-flex items-center px-2 py-1 ml-2 text-xs font-medium text-pink-700 rounded-md bg-pink-50 ring-1 ring-inset ring-pink-700/10"
+          >
+            Private
+          </span>
         </h1>
       </div>
       <div class="text-sm text-right text-gray-500">

--- a/lib/bike_brigade_web/live/campaign_signup_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/index.ex
@@ -90,7 +90,8 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
   defp fetch_campaigns(current_week, opts \\ []) do
     Delivery.list_campaigns(current_week,
       preload: [:program, :stats, :latest_message, :scheduled_message],
-      campaign_ids: opts[:campaign_ids]
+      campaign_ids: opts[:campaign_ids],
+      public: true
     )
     |> Enum.reverse()
     |> Utils.ordered_group_by(&LocalizedDateTime.to_date(&1.delivery_start))
@@ -137,7 +138,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
       |> assign(:copy, copy)
 
     ~H"""
-    <p class="flex flex-col md:flex-row items-center mt-0 text-sm text-gray-700">
+    <p class="flex flex-col items-center mt-0 text-sm text-gray-700 md:flex-row">
       <Icons.maki_bicycle_share class="flex-shrink-0 mb-2 mr-1.5 h-8 w-8 md:h-5 md:w-5 md:mb-0 text-gray-500" />
       <span class="flex space-x-2 font-bold md:font-normal">
         <span class={@class}><%= @copy %></span>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -24,7 +24,8 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
   @impl true
   def handle_params(%{"id" => id} = params, _url, socket) do
     with {num, ""} <- Integer.parse(id),
-         campaign when not is_nil(campaign) <- Delivery.get_campaign(num) do
+         campaign when not is_nil(campaign) <- Delivery.get_campaign(num),
+         %{public: true} <- campaign do
       {:noreply,
        socket
        |> assign_campaign(campaign)
@@ -208,23 +209,22 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     end
   end
 
-  @doc"""
+  @doc """
     Shows one of the following:
     - A "Sign up" button if the campaign is eligible for signing up
     - A "Unassign me" button if a rider is assigned to a task and wants to unassign themselves
     - The first name of other riders who have signed up for tasks.
   """
 
-
   attr :task, :any, required: true
 
   attr :campaign, :any, required: true
   attr :current_rider_id, :integer, required: true
   attr :id, :string, required: true
+
   defp signup_button(assigns) do
     ~H"""
     <div>
-
       <%= if @task.assigned_rider do %>
         <span :if={@task.assigned_rider.id != @current_rider_id} class="mr-2">
           <%= split_first_name(@task.assigned_rider.name) %>
@@ -244,7 +244,9 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
 
       <%= if task_eligible_for_signup(@task, @campaign) do %>
         <.button
-          phx-click={JS.push("signup_rider", value: %{task_id: @task.id, rider_id: @current_rider_id})}
+          phx-click={
+            JS.push("signup_rider", value: %{task_id: @task.id, rider_id: @current_rider_id})
+          }
           color={:secondary}
           id={"#{@id}-sign-up-task-#{@task.id}"}
           size={:xsmall}
@@ -260,7 +262,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
           color={:secondary}
           id={"#{@id}-task-over-#{@task.id}"}
           size={:xsmall}
-          class="w-full md:w-28 cursor-not-allowed bg-neutral-100 text-neutral-800"
+          class="w-full cursor-not-allowed md:w-28 bg-neutral-100 text-neutral-800"
         >
           Campaign over
         </.button>

--- a/priv/repo/migrations/20240415222446_add_public_to_campaign.exs
+++ b/priv/repo/migrations/20240415222446_add_public_to_campaign.exs
@@ -1,0 +1,9 @@
+defmodule BikeBrigade.Repo.Migrations.AddPublicToCampaign do
+  use Ecto.Migration
+
+  def change do
+    alter table(:campaigns) do
+      add :public, :boolean, default: false
+    end
+  end
+end

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -4,7 +4,6 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
 
   import Phoenix.LiveViewTest
 
-
   describe "Index - General" do
     setup ctx do
       program = fixture(:program, %{name: "ACME Delivery"})
@@ -22,6 +21,19 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
 
       for c <- campaigns do
         assert has_element?(live, "#campaign-#{c.id}")
+      end
+    end
+
+    test "It doesn't display private campaigns", ctx do
+      private_campaigns =
+        for _n <- 1..3 do
+          fixture(:campaign_private, %{program_id: ctx.program.id})
+        end
+
+      {:ok, live, _html} = live(ctx.conn, ~p"/campaigns/signup")
+
+      for c <- private_campaigns do
+        refute has_element?(live, "#campaign-#{c.id}")
       end
     end
 
@@ -148,6 +160,15 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
               {:redirect,
                %{flash: %{"error" => "Invalid campaign id."}, to: "/campaigns/signup/"}}} =
                live(ctx.conn, ~p"/campaigns/signup/foo/")
+    end
+
+    test "Invalid route for unpulished campaign", ctx do
+      campaign = fixture(:campaign_private, %{program_id: ctx.program.id})
+
+      assert {:error,
+              {:redirect,
+               %{flash: %{"error" => "Invalid campaign id."}, to: "/campaigns/signup/"}}} =
+               live(ctx.conn, ~p"/campaigns/signup/#{campaign.id}/")
     end
 
     test "Invalid route for campaign-task shows flash and redirects", ctx do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -49,7 +49,8 @@ defmodule BikeBrigade.Fixtures do
       %{
         delivery_start: DateTime.utc_now(),
         delivery_end: DateTime.utc_now() |> DateTime.add(60, :second),
-        location: Toronto.random_location()
+        location: Toronto.random_location(),
+        public: true
       }
       |> Map.merge(attrs)
       |> Delivery.create_campaign()
@@ -58,23 +59,35 @@ defmodule BikeBrigade.Fixtures do
     |> Repo.preload(program: [:items])
   end
 
+  def fixture(:campaign_private, attrs) do
+    attrs =
+      %{public: false}
+      |> Map.merge(attrs)
+
+    fixture(:campaign, attrs)
+  end
+
   def fixture(:campaign_with_riders, attrs) do
     campaign = fixture(:campaign)
 
-    riders = for _i <- 1..7 do
-      fixture(:rider)
-    end
+    riders =
+      for _i <- 1..7 do
+        fixture(:rider)
+      end
+
     Enum.each(riders, fn rider ->
       Delivery.create_campaign_rider(%{
-            campaign_id: campaign.id,
-            rider_id: rider.id
-            })
+        campaign_id: campaign.id,
+        rider_id: rider.id
+      })
     end)
+
     {campaign, riders}
   end
 
   def fixture(:rider, attrs) do
     location = Toronto.random_location()
+
     {:ok, rider} =
       %{
         name: fake_name(),


### PR DESCRIPTION
Added `public` flag to campaigns

It's defaulting to false for now as we are not opting in all campaigns for the portal just yet. Duplicating campaigns will duplicate its public/private state.

cc @sereprz - we should opt in the campaigns we're currently testing with, and make sure dispatchers know about this when you do the demo!

https://github.com/bikebrigade/dispatch/assets/34720/a6a42993-d177-4ed2-8341-6864a0b79d0a


Closes #300 