### PR TITLE
Add Task Assignment Log

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -7,6 +7,7 @@ defmodule BikeBrigade.Delivery do
   import Geo.PostGIS, only: [st_distance: 2]
   alias BikeBrigade.Riders.Rider
 
+  alias BikeBrigade.History
   alias BikeBrigade.Messaging
   alias BikeBrigade.Delivery.{Task, CampaignRider, TaskAssignmentLog}
 
@@ -120,7 +121,7 @@ defmodule BikeBrigade.Delivery do
   def assign_task(%Task{} = task, rider_id, user_id, opts \\ []) when is_list(opts) do
     Repo.transaction(fn ->
       {:ok, _log} =
-        create_task_assignment_log(%{
+       History.create_task_assignment_log(%{
           task_id: task.id,
           rider_id: rider_id,
           user_id: user_id,
@@ -142,7 +143,7 @@ defmodule BikeBrigade.Delivery do
       when not is_nil(assigned_rider_id) and is_list(opts) do
     Repo.transaction(fn ->
       {:ok, _log} =
-        create_task_assignment_log(%{
+        History.create_task_assignment_log(%{
           task_id: task.id,
           rider_id: assigned_rider_id,
           user_id: user_id,
@@ -1055,18 +1056,4 @@ defmodule BikeBrigade.Delivery do
     Opportunity.changeset(opportunity, attrs)
   end
 
-  @doc """
-  List all task assignment logs
-
-  Currently this table is used for analytics and not exposed in the app.
-  """
-  def list_task_assignment_logs() do
-    Repo.all(TaskAssignmentLog)
-  end
-
-  def create_task_assignment_log(attrs \\ %{}) do
-    %TaskAssignmentLog{timestamp: DateTime.utc_now()}
-    |> TaskAssignmentLog.changeset(attrs)
-    |> Repo.insert()
-  end
 end

--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -117,7 +117,7 @@ defmodule BikeBrigade.Delivery do
   Assign a task to a given rider (tracking the user that made the assignment)
   """
 
-  def assign_task(%Task{} = task, rider_id, user_id, opts \\ []) do
+  def assign_task(%Task{} = task, rider_id, user_id, opts \\ []) when is_list(opts) do
     Repo.transaction(fn ->
       {:ok, _log} =
         create_task_assignment_log(%{
@@ -138,7 +138,8 @@ defmodule BikeBrigade.Delivery do
   Unassign a task (tracking the user that made the unassignment)
   """
 
-  def unassign_task(%Task{assigned_rider_id: assigned_rider_id} = task, user_id, opts \\ []) when not is_nil(assigned_rider_id) do
+  def unassign_task(%Task{assigned_rider_id: assigned_rider_id} = task, user_id, opts \\ [])
+      when not is_nil(assigned_rider_id) and is_list(opts) do
     Repo.transaction(fn ->
       {:ok, _log} =
         create_task_assignment_log(%{

--- a/lib/bike_brigade/delivery/task_assignment_log.ex
+++ b/lib/bike_brigade/delivery/task_assignment_log.ex
@@ -1,0 +1,33 @@
+defmodule BikeBrigade.Delivery.TaskAssignmentLog do
+  use BikeBrigade.Schema
+
+  import Ecto.Changeset
+
+  alias BikeBrigade.Delivery.Task
+  alias BikeBrigade.Riders.Rider
+  alias BikeBrigade.Accounts.User
+
+  schema "task_assignment_logs" do
+    belongs_to :task, Task
+    belongs_to :rider, Rider
+    belongs_to :user, User
+
+    field :timestamp, :utc_datetime_usec
+    field :action, Ecto.Enum, values: [:assigned, :unassigned]
+
+    timestamps()
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [
+      :task_id,
+      :rider_id,
+      :user_id,
+      :timestamp,
+      :action
+    ])
+    |> validate_required([:task_id, :rider_id, :user_id, :timestamp, :action])
+    |> validate_inclusion(:action, [:assigned, :unassigned])
+  end
+end

--- a/lib/bike_brigade/history.ex
+++ b/lib/bike_brigade/history.ex
@@ -1,0 +1,21 @@
+defmodule BikeBrigade.History do
+  import Ecto.Query, warn: false
+  alias BikeBrigade.Repo
+
+  alias BikeBrigade.History.TaskAssignmentLog
+
+  @doc """
+  List all task assignment logs
+
+  Currently this table is used for analytics and not exposed in the app.
+  """
+  def list_task_assignment_logs() do
+    Repo.all(TaskAssignmentLog)
+  end
+
+  def create_task_assignment_log(attrs \\ %{}) do
+    %TaskAssignmentLog{timestamp: DateTime.utc_now()}
+    |> TaskAssignmentLog.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/bike_brigade/history/task_assignment_log.ex
+++ b/lib/bike_brigade/history/task_assignment_log.ex
@@ -1,4 +1,4 @@
-defmodule BikeBrigade.Delivery.TaskAssignmentLog do
+defmodule BikeBrigade.History.TaskAssignmentLog do
   use BikeBrigade.Schema
 
   import Ecto.Changeset

--- a/lib/bike_brigade_web/live/campaign_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_live/show.ex
@@ -244,7 +244,7 @@ defmodule BikeBrigadeWeb.CampaignLive.Show do
   def handle_event("assign_task", %{"task_id" => task_id, "rider_id" => rider_id}, socket) do
     {:ok, _task} =
       get_task(socket, task_id)
-      |> Delivery.update_task(%{assigned_rider_id: rider_id})
+      |> Delivery.assign_task(rider_id, socket.assigns.current_user.id)
 
     {:noreply, socket}
   end
@@ -256,7 +256,7 @@ defmodule BikeBrigadeWeb.CampaignLive.Show do
     if task.assigned_rider do
       {:ok, _task} =
         task
-        |> Delivery.update_task(%{assigned_rider_id: nil})
+        |> Delivery.unassign_task(socket.assigns.current_user.id)
     end
 
     {:noreply, socket}

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -92,7 +92,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     if task.assigned_rider do
       {:ok, _task} =
         task
-        |> Delivery.update_task(%{assigned_rider_id: nil})
+        |> Delivery.unassign_task(socket.assigns.current_user.id)
     end
 
     # If rider is no longer assigned to any tasks, remove them from the campaign
@@ -128,7 +128,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
 
     case Delivery.create_campaign_rider(attrs) do
       {:ok, _cr} ->
-        {:ok, _task} = Delivery.update_task(task, %{assigned_rider_id: rider_id})
+        {:ok, _task} = Delivery.assign_task(task, rider_id, socket.assigns.current_user.id)
         {:noreply, socket |> push_patch(to: ~p"/campaigns/signup/#{campaign}", replace: true)}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/priv/repo/migrations/20240416185206_create_task_assignment_log.exs
+++ b/priv/repo/migrations/20240416185206_create_task_assignment_log.exs
@@ -1,0 +1,15 @@
+defmodule BikeBrigade.Repo.Migrations.CreateTaskAssgignmentLog do
+  use Ecto.Migration
+
+  def change do
+    create table(:task_assignment_logs) do
+      add :task_id, references(:tasks)
+      add :rider_id, references(:riders)
+      add :user_id, references(:users)
+      add :timestamp, :utc_datetime_usec
+      add :action, :string
+
+      timestamps()
+    end
+  end
+end

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -1,7 +1,8 @@
 defmodule BikeBrigade.DeliveryTest do
   use BikeBrigade.DataCase
 
-  alias BikeBrigade.{LocalizedDateTime, Delivery, Delivery.Task}
+
+  alias BikeBrigade.{LocalizedDateTime, Delivery, Delivery.Task, History}
 
   use Phoenix.VerifiedRoutes, endpoint: BikeBrigadeWeb.Endpoint, router: BikeBrigadeWeb.Router
 
@@ -74,7 +75,7 @@ defmodule BikeBrigade.DeliveryTest do
 
     assert task.assigned_rider_id == rider.id
 
-    assert [log] = Delivery.list_task_assignment_logs()
+    assert [log] = History.list_task_assignment_logs()
     assert log.task_id == task.id
     assert log.rider_id == rider.id
     assert log.user_id == user.id
@@ -91,7 +92,7 @@ defmodule BikeBrigade.DeliveryTest do
 
     assert task.assigned_rider_id == nil
 
-    assert [log] = Delivery.list_task_assignment_logs()
+    assert [log] = History.list_task_assignment_logs()
     assert log.task_id == task.id
     assert log.rider_id == rider.id
     assert log.user_id == user.id

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -64,6 +64,41 @@ defmodule BikeBrigade.DeliveryTest do
     end
   end
 
+  test "assign_task/3" do
+    campaign = fixture(:campaign)
+    rider = fixture(:rider)
+    user = fixture(:user)
+    task = fixture(:task, %{campaign: campaign})
+
+    assert {:ok, task} = Delivery.assign_task(task, rider.id, user.id)
+
+    assert task.assigned_rider_id == rider.id
+
+    assert [log] = Delivery.list_task_assignment_logs()
+    assert log.task_id == task.id
+    assert log.rider_id == rider.id
+    assert log.user_id == user.id
+    assert log.action == :assigned
+  end
+
+  test "unassign_task/3" do
+    campaign = fixture(:campaign)
+    rider = fixture(:rider)
+    user = fixture(:user)
+    task = fixture(:task, %{campaign: campaign, assigned_rider_id: rider.id})
+
+    assert {:ok, task} = Delivery.unassign_task(task, user.id)
+
+    assert task.assigned_rider_id == nil
+
+    assert [log] = Delivery.list_task_assignment_logs()
+    assert log.task_id == task.id
+    assert log.rider_id == rider.id
+    assert log.user_id == user.id
+    assert log.action == :unassigned
+  end
+
+
   def item_name(%Task{task_items: [%{item: %{name: item_name}}]}), do: item_name
 
   defp to_uri(location) do

--- a/test/bike_brigade_web/live/campaign_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_live_test.exs
@@ -3,7 +3,8 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
 
   import Phoenix.LiveViewTest
   alias BikeBrigadeWeb.CampaignHelpers
-  alias BikeBrigade.LocalizedDateTime
+
+  alias BikeBrigade.{Delivery, LocalizedDateTime, History}
 
   describe "Index" do
     setup [:create_campaign, :login]
@@ -205,17 +206,16 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
       # assign the task
       view |> element("a", "Assign to #{rider.name}") |> render_click()
 
-      task = BikeBrigade.Delivery.get_task(task.id)
+      task = Delivery.get_task(task.id)
       assert task.assigned_rider_id == rider.id
 
       # Make sure we have a log
-      assert [log] = BikeBrigade.Delivery.list_task_assignment_logs()
+      assert [log] = History.list_task_assignment_logs()
       assert log.action == :assigned
       assert log.task_id == task.id
       assert log.rider_id == rider.id
       assert log.user_id == ctx.user.id
     end
-
 
     test "Can unassign a rider from a task", ctx do
       rider = hd(ctx.riders)
@@ -229,11 +229,11 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
       # unassign the task
       view |> element("a", "Unassign") |> render_click()
 
-      task = BikeBrigade.Delivery.get_task(task.id)
+      task = Delivery.get_task(task.id)
       assert task.assigned_rider_id == nil
 
       # Make sure we have a log
-      assert [log] = BikeBrigade.Delivery.list_task_assignment_logs()
+      assert [log] = History.list_task_assignment_logs()
       assert log.action == :unassigned
       assert log.task_id == task.id
       assert log.rider_id == rider.id

--- a/test/bike_brigade_web/live/campaign_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_live_test.exs
@@ -171,7 +171,10 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
       assert has_element?(view, ~s|[data-test-rider-window=1-11]|)
     end
 
-    test "'Rider Messaging' button is not visible without riders.", %{conn: conn, campaign: campaign} do
+    test "'Rider Messaging' button is not visible without riders.", %{
+      conn: conn,
+      campaign: campaign
+    } do
       {:ok, view, _html} = live(conn, ~p"/campaigns/#{campaign}")
       refute view |> element("a", "Rider Messaging") |> has_element?()
     end
@@ -186,6 +189,55 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
     } do
       {:ok, view, _html} = live(conn, ~p"/campaigns/#{campaign}")
       assert view |> element("a", "Rider Messaging") |> has_element?()
+    end
+
+    test "Can assign a rider to a task", ctx do
+      rider = hd(ctx.riders)
+      task = fixture(:task, %{campaign: ctx.campaign})
+      {:ok, view, _html} = live(ctx.conn, ~p"/campaigns/#{ctx.campaign}")
+
+      html = view |> element("a", task.dropoff_name) |> render_click()
+      assert html =~ "Unassigned"
+
+      html = view |> element("a", rider.name) |> render_click()
+      assert html =~ "No tasks"
+
+      # assign the task
+      view |> element("a", "Assign to #{rider.name}") |> render_click()
+
+      task = BikeBrigade.Delivery.get_task(task.id)
+      assert task.assigned_rider_id == rider.id
+
+      # Make sure we have a log
+      assert [log] = BikeBrigade.Delivery.list_task_assignment_logs()
+      assert log.action == :assigned
+      assert log.task_id == task.id
+      assert log.rider_id == rider.id
+      assert log.user_id == ctx.user.id
+    end
+
+
+    test "Can unassign a rider from a task", ctx do
+      rider = hd(ctx.riders)
+      task = fixture(:task, %{campaign: ctx.campaign, assigned_rider_id: rider.id})
+      {:ok, view, _html} = live(ctx.conn, ~p"/campaigns/#{ctx.campaign}")
+
+      view |> element("a", task.dropoff_name) |> render_click()
+
+      assert view |> element("a", task.dropoff_name) |> render =~ "Assigned"
+
+      # unassign the task
+      view |> element("a", "Unassign") |> render_click()
+
+      task = BikeBrigade.Delivery.get_task(task.id)
+      assert task.assigned_rider_id == nil
+
+      # Make sure we have a log
+      assert [log] = BikeBrigade.Delivery.list_task_assignment_logs()
+      assert log.action == :unassigned
+      assert log.task_id == task.id
+      assert log.rider_id == rider.id
+      assert log.user_id == ctx.user.id
     end
   end
 

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -1,6 +1,6 @@
 defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
   use BikeBrigadeWeb.ConnCase, async: false
-  alias BikeBrigade.LocalizedDateTime
+  alias BikeBrigade.{LocalizedDateTime, History}
 
   import Phoenix.LiveViewTest
 
@@ -175,7 +175,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       assert html =~ "Unassign me"
 
       # Make sure we have a log
-      assert [log] = BikeBrigade.Delivery.list_task_assignment_logs()
+      assert [log] = History.list_task_assignment_logs()
       assert log.action == :assigned
       assert log.task_id == ctx.task.id
       assert log.rider_id == ctx.rider.id
@@ -233,7 +233,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       refute render(live) =~ "Unassign me"
 
       # Make sure we have a log
-      assert [log] = BikeBrigade.Delivery.list_task_assignment_logs()
+      assert [log] = History.list_task_assignment_logs()
       assert log.action == :unassigned
       assert log.task_id == task.id
       assert log.rider_id == ctx.rider.id

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -173,6 +173,13 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       refute html =~ "Unassign me"
       html = live |> element("#signup-btn-desktop-sign-up-task-#{ctx.task.id}") |> render_click()
       assert html =~ "Unassign me"
+
+      # Make sure we have a log
+      assert [log] = BikeBrigade.Delivery.list_task_assignment_logs()
+      assert log.action == :assigned
+      assert log.task_id == ctx.task.id
+      assert log.rider_id == ctx.rider.id
+      assert log.user_id == ctx.user.id
     end
 
     test "Rider cannot signup for a task in the past", ctx do
@@ -224,6 +231,13 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       assert html =~ "Unassign me"
       element(live, "a#signup-btn-desktop-unassign-task-#{task.id}") |> render_click()
       refute render(live) =~ "Unassign me"
+
+      # Make sure we have a log
+      assert [log] = BikeBrigade.Delivery.list_task_assignment_logs()
+      assert log.action == :unassigned
+      assert log.task_id == task.id
+      assert log.rider_id == ctx.rider.id
+      assert log.user_id == ctx.user.id
     end
   end
 


### PR DESCRIPTION
Closes #323 

This adds a `TaskAssignmentLog` which tracks `user_id`, `rider_id`, `timestamp`, and `action` (`:assigned`, or `:unassigned`) for all assignment (whether rider directly or dispatcher).

