### PR TITLE
Add concept of public/private programs

### DIFF
--- a/lib/bike_brigade/delivery/program.ex
+++ b/lib/bike_brigade/delivery/program.ex
@@ -37,6 +37,9 @@ defmodule BikeBrigade.Delivery.Program do
     field :active, :boolean, default: true
     field :start_date, :date
 
+    # Default to public false
+    field :public, :boolean, default: false
+
     # TODO: this is me trying out virtual fields again
     field :campaign_count, :integer, virtual: true
 
@@ -58,17 +61,18 @@ defmodule BikeBrigade.Delivery.Program do
   def changeset(program, attrs) do
     program
     |> cast(attrs, [
+      :active,
       :name,
       :contact_name,
       :contact_email,
       :contact_phone,
       :campaign_blurb,
+      :default_item_id,
       :description,
       :lead_id,
+      :public,
       :spreadsheet_layout,
-      :start_date,
-      :active,
-      :default_item_id
+      :start_date
     ])
     |> validate_required([:name, :start_date])
     |> foreign_key_constraint(:lead_id)

--- a/lib/bike_brigade_web/helpers/campaign_helpers.ex
+++ b/lib/bike_brigade_web/helpers/campaign_helpers.ex
@@ -89,13 +89,15 @@ defmodule BikeBrigadeWeb.CampaignHelpers do
   end
 
   def name(campaign) do
-    campaign = campaign
-
     if campaign.program do
       campaign.program.name
     else
       campaign.name
     end
+  end
+
+  def public?(campaign) do
+    campaign.program.public
   end
 
   def campaign_date(campaign) do

--- a/lib/bike_brigade_web/live/campaign_live/index.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/index.html.heex
@@ -23,7 +23,7 @@
   <.live_component
     module={BikeBrigadeWeb.CampaignLive.DuplicateCampaignComponent}
     id={:duplicate}
-      title={@page_title}
+    title={@page_title}
     action={@live_action}
     campaign={@campaign}
     navigate={~p"/campaigns?current_week=#{@current_week}"}
@@ -87,6 +87,12 @@
                     data-test-group="campaign-name"
                   >
                     <%= name(c) %>
+                    <span
+                      :if={!public?(c)}
+                      class="inline-flex items-center px-2 py-1 ml-1 text-xs font-medium text-pink-700 rounded-md bg-pink-50 ring-1 ring-inset ring-pink-700/10"
+                    >
+                      Private
+                    </span>
                   </.link>
                 </div>
                 <div class="flex-shrink-0 space-y-1 md:space-y-0 md:space-x-2 md:flex">

--- a/lib/bike_brigade_web/live/campaign_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/show.html.heex
@@ -55,11 +55,11 @@
       </ul>
     </div>
 
-    <div class="md:flex relative inline-block dropdown">
+    <div class="relative inline-block md:flex dropdown">
       <.button
         :if={Enum.count(@riders) > 0}
         patch={~p"/campaigns/#{@campaign}/messaging/riders/"}
-        class="btn w-40 my-3 mr-3"
+        class="w-40 my-3 mr-3 btn"
       >
         Rider Messaging
       </.button>
@@ -81,6 +81,12 @@
         <.date date={campaign_date(@campaign)} />
         <h1 class="flex items-center pl-2 text-lg font-medium leading-6 text-gray-900">
           <%= name(@campaign) %>
+          <span
+            :if={!public?(@campaign)}
+            class="inline-flex items-center px-2 py-1 ml-2 text-xs font-medium text-pink-700 rounded-md bg-pink-50 ring-1 ring-inset ring-pink-700/10"
+          >
+            Private
+          </span>
         </h1>
       </div>
       <div class="text-sm text-right text-gray-500">

--- a/lib/bike_brigade_web/live/campaign_signup_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/index.ex
@@ -94,7 +94,8 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
   defp fetch_campaigns(current_week, opts \\ []) do
     Delivery.list_campaigns(current_week,
       preload: [:program, :stats, :latest_message, :scheduled_message],
-      campaign_ids: opts[:campaign_ids]
+      campaign_ids: opts[:campaign_ids],
+      public: true
     )
     |> Enum.reverse()
     |> Utils.ordered_group_by(&LocalizedDateTime.to_date(&1.delivery_start))

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -24,7 +24,8 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
   @impl true
   def handle_params(%{"id" => id} = params, _url, socket) do
     with {num, ""} <- Integer.parse(id),
-         campaign when not is_nil(campaign) <- Delivery.get_campaign(num) do
+         campaign when not is_nil(campaign) <- Delivery.get_campaign(num),
+         true <- public?(campaign) do
       {:noreply,
        socket
        |> assign_campaign(campaign)
@@ -208,7 +209,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     end
   end
 
-  @doc"""
+  @doc """
     Shows one of the following:
     - A "Sign up" button if the campaign is eligible for signing up
     - A "Unassign me" button if a rider is assigned to a task and wants to unassign themselves
@@ -219,10 +220,10 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
   attr :campaign, :any, required: true
   attr :current_rider_id, :integer, required: true
   attr :id, :string, required: true
+
   def signup_button(assigns) do
     ~H"""
     <div>
-
       <%= if @task.assigned_rider do %>
         <span :if={@task.assigned_rider.id != @current_rider_id} class="mr-2">
           <%= split_first_name(@task.assigned_rider.name) %>
@@ -242,7 +243,9 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
 
       <%= if task_eligible_for_signup(@task, @campaign) do %>
         <.button
-          phx-click={JS.push("signup_rider", value: %{task_id: @task.id, rider_id: @current_rider_id})}
+          phx-click={
+            JS.push("signup_rider", value: %{task_id: @task.id, rider_id: @current_rider_id})
+          }
           color={:secondary}
           id={"#{@id}-sign-up-task-#{@task.id}"}
           size={:xsmall}
@@ -258,7 +261,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
           color={:secondary}
           id={"#{@id}-task-over-#{@task.id}"}
           size={:xsmall}
-          class="w-full md:w-28 cursor-not-allowed bg-neutral-100 text-neutral-800"
+          class="w-full cursor-not-allowed md:w-28 bg-neutral-100 text-neutral-800"
         >
           Campaign over
         </.button>

--- a/lib/bike_brigade_web/live/program_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/program_live/form_component.html.heex
@@ -19,6 +19,12 @@
         />
         <.input type="textarea" field={{f, :description}} label="About (internal description)" />
         <.input type="date" field={{f, :start_date}} label="Start Date" placeholder="YYYY-MM-DD" />
+        <.input
+          type="checkbox"
+          field={{f, :public}}
+          label="Public"
+          help_text="Let riders sign up through the portal"
+        />
 
         <div class="space-y-1">
           <.header small>

--- a/lib/bike_brigade_web/live/program_live/index.html.heex
+++ b/lib/bike_brigade_web/live/program_live/index.html.heex
@@ -17,11 +17,18 @@
     <.link navigate={~p"/programs/#{program}"} class="link">
       <%= program.name %>
     </.link>
-    <%= if !program.active do %>
-      <span class="inline-block px-2 ml-2 text-xs border rounded-full">
-        Inactive
-      </span>
-    <% end %>
+    <span
+      :if={!program.active}
+      class="inline-flex items-center px-2 py-1 text-xs font-medium text-gray-600 rounded-md bg-gray-50 ring-1 ring-inset ring-gray-500/10"
+    >
+      Inactive
+    </span>
+    <span
+      :if={!program.public}
+      class="inline-flex items-center px-2 py-1 ml-1 text-xs font-medium text-pink-700 rounded-md bg-pink-50 ring-1 ring-inset ring-pink-700/10"
+    >
+      Private
+    </span>
   </:col>
   <:col :let={program} label="Campaigns" show_at={:large}>
     <%= program.campaign_count %>

--- a/lib/bike_brigade_web/live/program_live/show.html.heex
+++ b/lib/bike_brigade_web/live/program_live/show.html.heex
@@ -1,5 +1,17 @@
 <.header>
   <%= @program.name %>
+  <span
+    :if={!@program.active}
+    class="inline-flex items-center px-2 py-1 text-xs font-medium text-gray-600 rounded-md bg-gray-50 ring-1 ring-inset ring-gray-500/10"
+  >
+    Inactive
+  </span>
+  <span
+    :if={!@program.public}
+    class="inline-flex items-center px-2 py-1 ml-1 text-xs font-medium text-pink-700 rounded-md bg-pink-50 ring-1 ring-inset ring-pink-700/10"
+  >
+    Private
+  </span>
   <:subtitle>
     <%= @program.campaign_blurb %>
   </:subtitle>
@@ -7,7 +19,9 @@
     <.button navigate={~p"/programs/#{@program}/campaigns/new"}>
       New Campaign
     </.button>
-    <.button patch={~p"/programs/#{@program}/show/edit"} color={:white} class="ml-1">Edit</.button>
+    <.button patch={~p"/programs/#{@program}/show/edit"} color={:white} class="ml-1">
+      Edit
+    </.button>
   </:actions>
 </.header>
 

--- a/priv/repo/migrations/20240417005738_add_public_to_program.exs
+++ b/priv/repo/migrations/20240417005738_add_public_to_program.exs
@@ -1,0 +1,9 @@
+defmodule BikeBrigade.Repo.Migrations.AddPublicToProgram do
+  use Ecto.Migration
+
+  def change do
+    alter table(:programs) do
+      add(:public, :boolean, default: false)
+    end
+  end
+end

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -4,7 +4,6 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
 
   import Phoenix.LiveViewTest
 
-
   describe "Index - General" do
     setup ctx do
       program = fixture(:program, %{name: "ACME Delivery"})
@@ -22,6 +21,19 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
 
       for c <- campaigns do
         assert has_element?(live, "#campaign-#{c.id}")
+      end
+    end
+
+    test "It doesn't display private campaigns", ctx do
+      private_campaigns =
+        for _n <- 1..3 do
+          fixture(:campaign_private)
+        end
+
+      {:ok, live, _html} = live(ctx.conn, ~p"/campaigns/signup")
+
+      for c <- private_campaigns do
+        refute has_element?(live, "#campaign-#{c.id}")
       end
     end
 
@@ -148,6 +160,15 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
               {:redirect,
                %{flash: %{"error" => "Invalid campaign id."}, to: "/campaigns/signup/"}}} =
                live(ctx.conn, ~p"/campaigns/signup/foo/")
+    end
+
+    test "Invalid route for unpulished campaign", ctx do
+      campaign = fixture(:campaign_private)
+
+      assert {:error,
+              {:redirect,
+               %{flash: %{"error" => "Invalid campaign id."}, to: "/campaigns/signup/"}}} =
+               live(ctx.conn, ~p"/campaigns/signup/#{campaign.id}/")
     end
 
     test "Invalid route for campaign-task shows flash and redirects", ctx do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -23,7 +23,9 @@ defmodule BikeBrigade.Fixtures do
     {:ok, program} =
       %{
         name: Faker.Superhero.name(),
-        start_date: DateTime.utc_now()
+        start_date: DateTime.utc_now(),
+        # Make programs public by default in our fixturess
+        public: true
       }
       |> Map.merge(attrs)
       |> Delivery.create_program()
@@ -58,23 +60,37 @@ defmodule BikeBrigade.Fixtures do
     |> Repo.preload(program: [:items])
   end
 
+  def fixture(:campaign_private, attrs) do
+    private_program = fixture(:program, %{public: false})
+
+    attrs =
+      %{program_id: private_program.id}
+      |> Map.merge(attrs)
+
+    fixture(:campaign, attrs)
+  end
+
   def fixture(:campaign_with_riders, _attrs) do
     campaign = fixture(:campaign)
 
-    riders = for _i <- 1..7 do
-      fixture(:rider)
-    end
+    riders =
+      for _i <- 1..7 do
+        fixture(:rider)
+      end
+
     Enum.each(riders, fn rider ->
       Delivery.create_campaign_rider(%{
-            campaign_id: campaign.id,
-            rider_id: rider.id
-            })
+        campaign_id: campaign.id,
+        rider_id: rider.id
+      })
     end)
+
     {campaign, riders}
   end
 
   def fixture(:rider, attrs) do
     location = Toronto.random_location()
+
     {:ok, rider} =
       %{
         name: fake_name(),


### PR DESCRIPTION
After talking to @sereprz we decided to switch #324 to add track it on program
This adds a `public` flag to programs. It's defaulting to false for now as we are not opting in all programs for the portal just yet. 

Only campaigns for public programs are available for rider signup

![CleanShot 2024-04-17 at 16 48 00@2x](https://github.com/bikebrigade/dispatch/assets/34720/a05f6bf1-c447-42cf-986a-da799a58472b)

![CleanShot 2024-04-17 at 16 44 03@2x](https://github.com/bikebrigade/dispatch/assets/34720/573c392b-753e-4c06-80d1-987fe846070e)

![CleanShot 2024-04-17 at 16 44 12@2x](https://github.com/bikebrigade/dispatch/assets/34720/913c757a-7d54-4b87-8195-38211dc39dd4)

