### PR TITLE
Only show first initial for recipient

### DIFF
--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -262,7 +262,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
           color={:secondary}
           id={"#{@id}-task-over-#{@task.id}"}
           size={:xsmall}
-          class="w-full md:w-28 cursor-not-allowed bg-neutral-100 text-neutral-800"
+          class="w-full cursor-not-allowed md:w-28 bg-neutral-100 text-neutral-800"
         >
           Campaign over
         </.button>
@@ -279,5 +279,9 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
   # determine if a rider is eligible to "unassign" themselves
   defp task_eligigle_for_unassign(task, campaign, current_rider_id) do
     task.assigned_rider.id == current_rider_id && !campaign_in_past(campaign)
+  end
+
+  defp first_initial(name) do
+    name |> String.first() |> String.upcase()
   end
 end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -39,7 +39,7 @@
 <ul class="flex flex-col text-xs md:hidden">
   <li :for={t <- @tasks} class="w-full mb-8">
     <div class="flex justify-between px-4 py-3 font-bold bg-slate-200">
-      <span><%= first_initial(t.dropoff_name) %></span>
+      <span data-test-id={"dropoff-name-#{t.id}"}><%= first_initial(t.dropoff_name) %></span>
       <span>Pickup: <%= pickup_window(@campaign) %></span>
     </div>
     <div class="flex flex-col bg-white shadow">

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -1,9 +1,9 @@
-<.header class="text-center mt-4 mb-8 md:text-left">
+<.header class="mt-4 mb-8 text-center md:text-left">
   <div class="hidden md:flex">
     <%= @campaign.program.name %> - <%= campaign_date(@campaign) %>
   </div>
-  <div class="text-xl flex flex-col mb-4 md:hidden"><%= @campaign.program.name %></div>
-  <div class="text-sm mt-2 md:hidden">Deliveries for <%= campaign_date(@campaign) %></div>
+  <div class="flex flex-col mb-4 text-xl md:hidden"><%= @campaign.program.name %></div>
+  <div class="mt-2 text-sm md:hidden">Deliveries for <%= campaign_date(@campaign) %></div>
   <:subtitle>
     <span class="text-sm font-bold">Pickup: <%= @campaign.location.address %></span>
     <span :if={@campaign.program.campaign_blurb}>- <%= @campaign.program.campaign_blurb %></span>
@@ -19,7 +19,7 @@
     <:col :let={task} label="Delivery Size">
       <.get_delivery_size task={task} />
     </:col>
-    <:col :let={task} label="Recipient"><%= task.dropoff_name %></:col>
+    <:col :let={task} label="Recipient"><%= first_initial(task.dropoff_name) %></:col>
     <:col :let={task} label="Dropoff Neighbourhood">
       <%= Locations.neighborhood(task.dropoff_location) %>
     </:col>
@@ -38,19 +38,19 @@
 <!-- Mobile list of tasks -->
 <ul class="flex flex-col text-xs md:hidden">
   <li :for={t <- @tasks} class="w-full mb-8">
-    <div class="flex px-4 py-3 font-bold bg-slate-200 justify-between">
-      <span><%= t.dropoff_name %></span>
+    <div class="flex justify-between px-4 py-3 font-bold bg-slate-200">
+      <span><%= first_initial(t.dropoff_name) %></span>
       <span>Pickup: <%= pickup_window(@campaign) %></span>
     </div>
     <div class="flex flex-col bg-white shadow">
-      <div class="flex py-2 border-b p-4 items-center">
+      <div class="flex items-center p-4 py-2 border-b">
         <span class="pr-2 ">Delivery size:</span>
         <span class="italic">
           <.get_delivery_size task={t} />
         </span>
       </div>
 
-      <div class="flex px-4 py-2 items-start border-b space-x-2">
+      <div class="flex items-start px-4 py-2 space-x-2 border-b">
         <span>Dropoff Neighbourhood:</span>
         <span><%= Locations.neighborhood(t.dropoff_location) %></span>
       </div>

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -139,7 +139,11 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
 
     test "we see pertinent task information", ctx do
       {:ok, _live, html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
-      assert html =~ ctx.task.dropoff_name
+
+      # we only show the first initial of the dropoff name
+      refute html =~ ctx.task.dropoff_name
+      assert html =~ ctx.task.dropoff_name |> String.first() |> String.upcase()
+
       assert html =~ BikeBrigade.Locations.neighborhood(ctx.task.dropoff_location)
     end
 

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -4,7 +4,6 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
 
   import Phoenix.LiveViewTest
 
-
   describe "Index - General" do
     setup ctx do
       program = fixture(:program, %{name: "ACME Delivery"})
@@ -138,11 +137,13 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
     end
 
     test "we see pertinent task information", ctx do
-      {:ok, _live, html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
+      {:ok, live, html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
 
       # we only show the first initial of the dropoff name
       refute html =~ ctx.task.dropoff_name
-      assert html =~ ctx.task.dropoff_name |> String.first() |> String.upcase()
+
+      assert live |> element("[data-test-id=dropoff-name-#{ctx.task.id}]") |> render =~
+               ctx.task.dropoff_name |> String.first() |> String.upcase()
 
       assert html =~ BikeBrigade.Locations.neighborhood(ctx.task.dropoff_location)
     end


### PR DESCRIPTION
Our spreadsheets never show recipient names, just first initials.


Before 
<img width="390" alt="CleanShot 2024-04-17 at 17 07 02@2x" src="https://github.com/bikebrigade/dispatch/assets/34720/0e99bb48-f99b-4163-bb05-d4e8c12e9a13">

After
<img width="387" alt="CleanShot 2024-04-17 at 17 07 21@2x" src="https://github.com/bikebrigade/dispatch/assets/34720/73d93392-0f7f-4782-bbab-436dc28fa909">
