### PR TITLE
Fix: sort tasks by neighbourhoods.

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -458,9 +458,7 @@ defmodule BikeBrigade.Delivery do
       |> Repo.preload(:location)
 
     # Does a nested preload to get tasks' assigned riders without doing an extra db query
-    tasks =
-      Repo.preload(all_tasks, assigned_rider: fn _ -> all_riders end)
-    |> Enum.sort_by(fn t -> t.dropoff_location.neighborhood.name end)
+    tasks = Repo.preload(all_tasks, assigned_rider: fn _ -> all_riders end)
 
     riders = Repo.preload(all_riders, assigned_tasks: fn _ -> all_tasks end)
 

--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -436,7 +436,7 @@ defmodule BikeBrigade.Delivery do
       |> task_load_location()
       |> order_by(:id)
       |> Repo.all()
-      |> Repo.preload([:pickup_location, :dropoff_location, task_items: [:item]])
+      |> Repo.preload([:pickup_location, dropoff_location: [:neighborhood], task_items: [:item]])
 
     all_riders =
       Repo.all(
@@ -458,7 +458,9 @@ defmodule BikeBrigade.Delivery do
       |> Repo.preload(:location)
 
     # Does a nested preload to get tasks' assigned riders without doing an extra db query
-    tasks = Repo.preload(all_tasks, assigned_rider: fn _ -> all_riders end)
+    tasks =
+      Repo.preload(all_tasks, assigned_rider: fn _ -> all_riders end)
+    |> Enum.sort_by(fn t -> t.dropoff_location.neighborhood.name end)
 
     riders = Repo.preload(all_riders, assigned_tasks: fn _ -> all_tasks end)
 

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -173,10 +173,15 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
   defp assign_campaign(socket, campaign) do
     {riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
 
+    tasks_with_neighborhoods =
+      tasks
+      |> Enum.map(fn task -> {task, Locations.neighborhood(task.dropoff_location)} end)
+      |> Enum.sort_by(&elem(&1, 0))
+
     socket
     |> assign(:campaign, campaign)
     |> assign(:riders, riders)
-    |> assign(:tasks, tasks)
+    |> assign(:tasks_with_neighborhoods, tasks_with_neighborhoods)
   end
 
   ## Module specific components

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -113,7 +113,6 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
 
   def handle_event("signup_rider", %{"rider_id" => rider_id, "task_id" => task_id}, socket) do
     %{campaign: campaign, tasks: tasks} = socket.assigns
-
     task = Enum.find(tasks, fn task -> task.id == task_id end)
 
     attrs = %{
@@ -173,6 +172,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
 
   defp assign_campaign(socket, campaign) do
     {riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
+    tasks = Enum.sort_by(tasks, fn t -> t.dropoff_location.neighborhood.name end)
 
     socket
     |> assign(:campaign, campaign)

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -113,6 +113,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
 
   def handle_event("signup_rider", %{"rider_id" => rider_id, "task_id" => task_id}, socket) do
     %{campaign: campaign, tasks: tasks} = socket.assigns
+
     task = Enum.find(tasks, fn task -> task.id == task_id end)
 
     attrs = %{
@@ -173,15 +174,10 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
   defp assign_campaign(socket, campaign) do
     {riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
 
-    tasks_with_neighborhoods =
-      tasks
-      |> Enum.map(fn task -> {task, Locations.neighborhood(task.dropoff_location)} end)
-      |> Enum.sort_by(&elem(&1, 0))
-
     socket
     |> assign(:campaign, campaign)
     |> assign(:riders, riders)
-    |> assign(:tasks_with_neighborhoods, tasks_with_neighborhoods)
+    |> assign(:tasks, tasks)
   end
 
   ## Module specific components

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -12,20 +12,20 @@
 
 <!-- Desktop Table of tasks -->
 <section class="hidden md:block">
-  <.table id="tasks" rows={@tasks_with_neighborhoods}>
+  <.table id="tasks" rows={@tasks}>
     <:col :let={_task} label="Pickup time">
       <%= pickup_window(@campaign) %>
     </:col>
-    <:col :let={{task, _}} label="Delivery Size">
+    <:col :let={task} label="Delivery Size">
       <.get_delivery_size task={task} />
     </:col>
-    <:col :let={{task, _}} label="Recipient"><%= first_initial(task.dropoff_name) %></:col>
-    <:col :let={{task, neighbourhood}} label="Dropoff Neighbourhood">
-      <%= neighbourhood %>
+    <:col :let={task} label="Recipient"><%= first_initial(task.dropoff_name) %></:col>
+    <:col :let={task} label="Dropoff Neighbourhood">
+      <%= task.dropoff_location.neighborhood.name %>
     </:col>
-    <:col :let={{task, _}} label="Notes"><%= task.delivery_status_notes %>
+    <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
       <.truncated_riders_notes note={task.rider_notes || "--"} /></:col>
-    <:action :let={{task, _}}>
+    <:action :let={task}>
       <.signup_button
         id="signup-btn-desktop"
         campaign={@campaign}
@@ -37,7 +37,7 @@
 </section>
 <!-- Mobile list of tasks -->
 <ul class="flex flex-col text-xs md:hidden">
-  <li :for={{t, _} <- @tasks_with_neighborhoods} class="w-full mb-8">
+  <li :for={t <- @tasks} class="w-full mb-8">
     <div class="flex justify-between px-4 py-3 font-bold bg-slate-200">
       <span data-test-id={"dropoff-name-#{t.id}"}><%= first_initial(t.dropoff_name) %></span>
       <span>Pickup: <%= pickup_window(@campaign) %></span>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -12,20 +12,20 @@
 
 <!-- Desktop Table of tasks -->
 <section class="hidden md:block">
-  <.table id="tasks" rows={@tasks}>
+  <.table id="tasks" rows={@tasks_with_neighborhoods}>
     <:col :let={_task} label="Pickup time">
       <%= pickup_window(@campaign) %>
     </:col>
-    <:col :let={task} label="Delivery Size">
+    <:col :let={{task, _}} label="Delivery Size">
       <.get_delivery_size task={task} />
     </:col>
-    <:col :let={task} label="Recipient"><%= first_initial(task.dropoff_name) %></:col>
-    <:col :let={task} label="Dropoff Neighbourhood">
-      <%= Locations.neighborhood(task.dropoff_location) %>
+    <:col :let={{task, _}} label="Recipient"><%= first_initial(task.dropoff_name) %></:col>
+    <:col :let={{task, neighbourhood}} label="Dropoff Neighbourhood">
+      <%= neighbourhood %>
     </:col>
-    <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
+    <:col :let={{task, _}} label="Notes"><%= task.delivery_status_notes %>
       <.truncated_riders_notes note={task.rider_notes || "--"} /></:col>
-    <:action :let={task}>
+    <:action :let={{task, _}}>
       <.signup_button
         id="signup-btn-desktop"
         campaign={@campaign}
@@ -37,7 +37,7 @@
 </section>
 <!-- Mobile list of tasks -->
 <ul class="flex flex-col text-xs md:hidden">
-  <li :for={t <- @tasks} class="w-full mb-8">
+  <li :for={{t, _} <- @tasks_with_neighborhoods} class="w-full mb-8">
     <div class="flex justify-between px-4 py-3 font-bold bg-slate-200">
       <span data-test-id={"dropoff-name-#{t.id}"}><%= first_initial(t.dropoff_name) %></span>
       <span>Pickup: <%= pickup_window(@campaign) %></span>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -21,7 +21,7 @@
     </:col>
     <:col :let={task} label="Recipient"><%= first_initial(task.dropoff_name) %></:col>
     <:col :let={task} label="Dropoff Neighbourhood">
-      <%= task.dropoff_location.neighborhood.name %>
+      <%= Locations.neighborhood(task.dropoff_location) %>
     </:col>
     <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
       <.truncated_riders_notes note={task.rider_notes || "--"} /></:col>


### PR DESCRIPTION
While pairing with @chadmohr he mentioned that we might want to consider grouping tasks by neighbourhood — sometimes tasks are all going to the same building / is useful for riders who can/want to take multiple deliveries to the same location. 

### Before

![CleanShot 2024-04-26 at 11 26 08@2x](https://github.com/bikebrigade/dispatch/assets/12987958/9f935a3b-e30e-4fd5-a337-e79ea7eca444)

### After

![CleanShot 2024-04-26 at 11 25 12@2x](https://github.com/bikebrigade/dispatch/assets/12987958/13a4e52d-8cc0-4185-92b6-4a4addca2111)
