### PR TITLE
Perform better caching on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,30 @@ jobs:
       with:
         elixir-version: '1.14.2' # Define the elixir version [required]
         otp-version: '25' # Define the OTP version [required]
-    - name: Restore dependencies cache
-      uses: actions/cache@v2
-      with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
+
+    - name: Cache Elixir deps
+        id: elixir-deps-cache
+        uses: actions/cache@v2.1.7
+        with:
+          path: |
+            **/deps
+          key: |
+            ${{ runner.os }}-elixir-deps-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-elixir-deps-
+
+      - name: Cache Elixir build
+        id: elixir-build-cache
+        uses: actions/cache@v2.1.7
+        with:
+          path: |
+            **/_build
+          key: |
+            ${{ runner.os }}-elixir-build-${{ hashFiles('**/mix.lock') }}-${{ hashFiles( '**/lib/**/*.{ex,eex}', '**/config/*.exs', '**/mix.exs' ) }}
+          restore-keys: |
+            ${{ runner.os }}-elixir-build-${{ hashFiles('**/mix.lock') }}-
+            ${{ runner.os }}-elixir-build-
+
     - name: Install dependencies
       run: mix deps.get
     - name: Compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     name: Build and test
     runs-on: ubuntu-latest
 
@@ -25,14 +24,14 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Elixir
-      uses: erlef/setup-elixir@v1
-      with:
-        elixir-version: '1.14.2' # Define the elixir version [required]
-        otp-version: '25' # Define the OTP version [required]
+      - uses: actions/checkout@v2
+      - name: Set up Elixir
+        uses: erlef/setup-elixir@v1
+        with:
+          elixir-version: '1.14.2'
+          otp-version: '25'
 
-    - name: Cache Elixir deps
+      - name: Cache Elixir deps
         id: elixir-deps-cache
         uses: actions/cache@v2.1.7
         with:
@@ -55,13 +54,13 @@ jobs:
             ${{ runner.os }}-elixir-build-${{ hashFiles('**/mix.lock') }}-
             ${{ runner.os }}-elixir-build-
 
-    - name: Install dependencies
-      run: mix deps.get
-    - name: Compile
-      run: mix compile
-    - name: Install JS dependencies
-      run: npm install --prefix=assets
-    - name: Compile assets
-      run: mix assets.deploy
-    - name: Run tests
-      run: mix test
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Compile
+        run: mix compile
+      - name: Install JS dependencies
+        run: npm install --prefix=assets
+      - name: Compile assets
+        run: mix assets.deploy
+      - name: Run tests
+        run: mix test

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -115,6 +115,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     %{campaign: campaign, tasks: tasks} = socket.assigns
     task = Enum.find(tasks, fn task -> task.id == task_id end)
 
+
     attrs = %{
       # this is arbitrary and not actually used by dispatchers anymore.
       "rider_capacity" => "1",

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -115,7 +115,6 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     %{campaign: campaign, tasks: tasks} = socket.assigns
     task = Enum.find(tasks, fn task -> task.id == task_id end)
 
-
     attrs = %{
       # this is arbitrary and not actually used by dispatchers anymore.
       "rider_capacity" => "1",


### PR DESCRIPTION
This speeds up subsequent ci runs (ie, when you hit "retrigger workflow" - as it caches the _build folder on initial run.)

Solution found [here](https://elixirforum.com/t/github-action-cache-elixir-always-recompiles-dependencies-elixir-1-13-3/45994/7)

closes #345 


Here's a video showing sets of runs, the first two tabs I swap between in the video are a triggered re-run on the old config, and the second set of tabs is for this PR, demonstrating that subsequent runs are faster:

https://github.com/bikebrigade/dispatch/assets/12987958/66999dff-6039-47fe-bc29-151f9d8cb456


