### PR TITLE
Fix: crashing sort by on neighbourhoods

### DIFF
--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -172,7 +172,12 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
 
   defp assign_campaign(socket, campaign) do
     {riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
-    tasks = Enum.sort_by(tasks, fn t -> t.dropoff_location.neighborhood.name end)
+    tasks = Enum.sort_by(tasks, fn t ->
+      case t.dropoff_location.neighborhood do
+        nil -> ""
+        x -> x.name
+      end
+    end)
 
     socket
     |> assign(:campaign, campaign)

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -172,12 +172,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
 
   defp assign_campaign(socket, campaign) do
     {riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
-    tasks = Enum.sort_by(tasks, fn t ->
-      case t.dropoff_location.neighborhood do
-        nil -> ""
-        x -> x.name
-      end
-    end)
+    tasks = Enum.sort_by(tasks, fn t -> Locations.neighborhood(t.dropoff_location) end)
 
     socket
     |> assign(:campaign, campaign)


### PR DESCRIPTION
Currently, the signup show.ex file crashes if a task doesn't have a neighbourhood - `dropoff_location.neighborhood` can be nil - this handles for that case. 