### PR TITLE
Add needs triage label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,3 @@
+---
+label: needs triage
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Use this template for reporting bugs.
+label: needs triage, bug
 ---
 
 **Describe the bug**


### PR DESCRIPTION
Adding a blank issue template with a default label of `needs triage` (helpful for planning/prioritizing)
Also adding defaults labels to the bug report