### PR TITLE
Message riders even if they are not assigned any tasks

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -572,7 +572,7 @@ defmodule BikeBrigade.Delivery do
     {riders, _} = campaign_riders_and_tasks(campaign)
 
     msgs =
-      for rider <- riders, rider != nil, rider.assigned_tasks != [] do
+      for rider <- riders, rider != nil do
         {:ok, msg} = send_campaign_message(%Campaign{} = campaign, rider)
 
         msg


### PR DESCRIPTION
There's a little-known "feature" where we only message riders on campaigns if they're assigned a delivery.

I want to get rid of it for three reasons

1) It's counterintuitive and not documented well for dispatchers
2) As we roll out the rider portal, dispatchers aren't going to be adding riders to campaigns so it's not pertinent anymore
3) I want to use the campaigns' scheduled messanger feature for a hacky way to do scheduled bulk messages announcing the portal (#352 ) and this has to happen for it to work

@chadmohr I think you might be the only person that's aware of this "feature" - pinging you in case you have any concerns