### PR TITLE
Hide delivery notes on rider campaign signup

### DIFF
--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -23,8 +23,6 @@
     <:col :let={task} label="Dropoff Neighbourhood">
       <%= Locations.neighborhood(task.dropoff_location) %>
     </:col>
-    <:col :let={task} label="Notes"><%= task.delivery_status_notes %>
-      <.truncated_riders_notes note={task.rider_notes || "--"} /></:col>
     <:action :let={task}>
       <.signup_button
         id="signup-btn-desktop"


### PR DESCRIPTION
![CleanShot 2024-05-08 at 14 19 02@2x](https://github.com/bikebrigade/dispatch/assets/12987958/42e10485-48e1-4eb0-bfb5-8dfa4d14947d)

Fixes #340 