### PR TITLE
Disable "Copy Riders" checkbox in campaign duplication

### DIFF
--- a/lib/bike_brigade_web/live/campaign_live/duplicate_campaign_component.ex
+++ b/lib/bike_brigade_web/live/campaign_live/duplicate_campaign_component.ex
@@ -45,7 +45,7 @@ defmodule BikeBrigadeWeb.CampaignLive.DuplicateCampaignComponent do
         </div>
 
         <.input type="checkbox" checked field={{f, :duplicate_deliveries}} label="Copy Deliveries" />
-        <.input type="checkbox" checked field={{f, :duplicate_riders}} label="Copy Riders" />
+        <.input type="checkbox" field={{f, :duplicate_riders}} label="Copy Riders" />
 
         <:actions>
           <.button type="submit" phx-disable-with="Saving...">


### PR DESCRIPTION
Closes #332
![CleanShot 2024-05-22 at 13 30 16@2x](https://github.com/bikebrigade/dispatch/assets/34720/c8382064-2827-4772-b0b2-e2edd78cae40)

