### PR TITLE
Follow best practices for the OTP login codes

### DIFF
--- a/lib/bike_brigade/authentication_messenger.ex
+++ b/lib/bike_brigade/authentication_messenger.ex
@@ -77,7 +77,7 @@ defmodule BikeBrigade.AuthenticationMessenger do
     msg = [
       from: Messaging.outbound_number(),
       to: phone,
-      body: "Your BikeBrigade access code is #{token}."
+      body: "Your BikeBrigade access code is #{token}.\n\n@#{BikeBrigadeWeb.Endpoint.host()} ##{token}"
     ]
 
     SmsService.send_sms(msg)

--- a/lib/bike_brigade_web/live/login_live.html.heex
+++ b/lib/bike_brigade_web/live/login_live.html.heex
@@ -34,7 +34,11 @@
           </div>
 
           <div class="text-center ">
-            <.button href="https://www.bikebrigade.ca/volunteer-rider-sign-up" color={:white} size={:small}>
+            <.button
+              href="https://www.bikebrigade.ca/volunteer-rider-sign-up"
+              color={:white}
+              size={:small}
+            >
               Sign Up!
             </.button>
           </div>
@@ -65,7 +69,14 @@
             </p>
           </div>
           <.input type="hidden" field={{f, :phone}} />
-          <.input type="text" field={{f, :token_attempt}} label="Authentication Code" />
+          <.input
+            type="text"
+            field={{f, :token_attempt}}
+            label="Authentication Code"
+            inputmode="numeric"
+            autocomplete="one-time-code"
+            pattern="\d{6}"
+          />
           <:actions>
             <.button type="submit" class="w-full">Sign in</.button>
           </:actions>


### PR DESCRIPTION
Follows the steps from: https://web.dev/articles/sms-otp-form
I opted to not invoke the WebOTP API as it feels like overkill - I don't like the ux where the webapp is asking permission to read your texts. The two steps here will prompt the phone to auto-paste the code (I hope 🤞 )

Addresses one half of #307 