### PR TITLE
Show item name and description in signup

### DIFF
--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -183,16 +183,10 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
   ## Module specific components
 
   defp get_delivery_size(assigns) do
-    item_list =
-      Enum.map(assigns.task.task_items, fn task_item ->
-        "#{task_item.count} #{task_item.item.category}"
-      end)
-
-    assigns = assign(assigns, :item_list, item_list)
-
     ~H"""
-    <div :for={item <- @item_list}>
-      <%= item %>
+    <div :for={task_item <- @task.task_items}>
+      <span :if={task_item.count > 1}> task_item.count </span>
+      <%= Inflex.inflect(task_item.item.name, task_item.count) %>
     </div>
     """
   end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -190,7 +190,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
       <%= if task_item.item.description && task_item.item.description != "" do %>
         <div class="flex items-center">
           <details>
-            <summary class="cursor-pointer">
+            <summary class="cursor-pointer" title={task_item.item.description}>
               <%= Inflex.inflect(task_item.item.name, task_item.count) %>
             </summary>
             <%= task_item.item.description %>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -191,23 +191,6 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     """
   end
 
-  defp truncated_riders_notes(assigns) do
-    if String.length(assigns.note) > 40 do
-      ~H"""
-      <div class="w-[40ch] flex items-center">
-        <details>
-          <summary class="cursor-pointer"><%= String.slice(@note, 0..40) %>...</summary>
-          <%= @note %>
-        </details>
-      </div>
-      """
-    else
-      ~H"""
-      <div><%= @note %></div>
-      """
-    end
-  end
-
   @doc """
     Shows one of the following:
     - A "Sign up" button if the campaign is eligible for signing up

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -184,9 +184,21 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
 
   defp get_delivery_size(assigns) do
     ~H"""
-    <div :for={task_item <- @task.task_items}>
+    <div :for={task_item <- @task.task_items} class="flex items-center">
       <span :if={task_item.count > 1}> task_item.count </span>
-      <%= Inflex.inflect(task_item.item.name, task_item.count) %>
+
+      <%= if task_item.item.description && task_item.item.description != "" do %>
+        <div class="flex items-center">
+          <details>
+            <summary class="cursor-pointer">
+              <%= Inflex.inflect(task_item.item.name, task_item.count) %>
+            </summary>
+            <%= task_item.item.description %>
+          </details>
+        </div>
+      <% else %>
+        <%= Inflex.inflect(task_item.item.name, task_item.count) %>
+      <% end %>
     </div>
     """
   end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -16,7 +16,7 @@
     <:col :let={_task} label="Pickup time">
       <%= pickup_window(@campaign) %>
     </:col>
-    <:col :let={task} label="Delivery Size">
+    <:col :let={task} label="Delivery">
       <.get_delivery_size task={task} />
     </:col>
     <:col :let={task} label="Recipient"><%= initials(task.dropoff_name) %></:col>
@@ -42,7 +42,7 @@
     </div>
     <div class="flex flex-col bg-white shadow">
       <div class="flex items-center p-4 py-2 border-b">
-        <span class="pr-2 ">Delivery size:</span>
+        <span class="pr-2 ">Delivery:</span>
         <span class="italic">
           <.get_delivery_size task={t} />
         </span>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -53,11 +53,6 @@
         <span><%= Locations.neighborhood(t.dropoff_location) %></span>
       </div>
 
-      <div :if={t.rider_notes} class="flex flex-col justify-center px-4 py-2 border-b-2">
-        <span>Notes:</span>
-        <span><%= t.rider_notes %></span>
-      </div>
-
       <div class="flex flex-col justify-center px-4 py-2 border-b-2">
         <.signup_button
           id="signup-btn-mobile"

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -200,6 +200,10 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
 
       assert live |> element("[data-test-id=dropoff-name-#{ctx.task.id}]") |> render =~ "CJH"
       assert html =~ BikeBrigade.Locations.neighborhood(ctx.task.dropoff_location)
+
+      # We show the name of the item
+      assert html =~ "Burrito"
+
     end
 
     test "Invalid route for campaign shows flash and redirects", ctx do

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -201,8 +201,9 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       assert live |> element("[data-test-id=dropoff-name-#{ctx.task.id}]") |> render =~ "CJH"
       assert html =~ BikeBrigade.Locations.neighborhood(ctx.task.dropoff_location)
 
-      # We show the name of the item
+      # We show the name and description of the item
       assert html =~ "Burrito"
+      assert html =~ "a large burrito with all the fixings"
 
     end
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -223,10 +223,9 @@ defmodule BikeBrigade.Fixtures do
 
   defp fake_item() do
     %{
-      name: "Foodshare Box",
-      plural: "Foodshare Boxes",
-      description: "a box",
-      category: "Foodshare Box"
+      name: "Burrito",
+      description: "a large burrito with all the fixings",
+      category: "Prepared Food"
     }
   end
 end


### PR DESCRIPTION
We show the item name and description when signing up now. I used the description/summary thing with minimal styling - but honestly I think it's good for now.

Note also I got rid of the number when it's one item

## Desktop
![CleanShot 2024-05-22 at 16 36 34](https://github.com/bikebrigade/dispatch/assets/34720/aae98e12-c706-452c-9364-fcd1dd5cffb6)

## Mobile
![CleanShot 2024-05-22 at 16 35 21](https://github.com/bikebrigade/dispatch/assets/34720/aec13b51-ae62-43bd-936f-df927dc52891)

Closes #364 #370 
