### PR TITLE
Make deploys queue instead of running in parallel

### DIFF
--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - staging
+
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   deploy:
     name: Deploy


### PR DESCRIPTION
I just merged several PRs at once, which triggers a deploy action. If we try to deploy before an ongoing deploy is finished, we get an error (see https://github.com/bikebrigade/dispatch/actions/runs/9209643022 for an example)

This PR adds a setting to the actions to queue them up and wait for the previous deployment to finish so we don't run into this.