### PR TITLE
Add prompt if the rider is unassigning a delivery today

### DIFF
--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -1,4 +1,5 @@
 defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
+  alias BikeBrigade.LocalizedDateTime
   use BikeBrigadeWeb, :live_view
 
   import BikeBrigadeWeb.CampaignHelpers
@@ -224,7 +225,12 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
         </span>
 
         <.button
-          :if={task_eligigle_for_unassign(@task, @campaign, @current_rider_id)}
+          :if={task_eligigle_for_unassign?(@task, @campaign, @current_rider_id)}
+          data-confirm={
+            if campaign_today?(@campaign),
+              do:
+                "This delivery starts today. If you need to unassign yourself, please also text dispatch to let us know!"
+          }
           phx-click={JS.push("unassign_task", value: %{task_id: @task.id})}
           id={"#{@id}-unassign-task-#{@task.id}"}
           color={:red}
@@ -235,7 +241,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
         </.button>
       <% end %>
 
-      <%= if task_eligible_for_signup(@task, @campaign) do %>
+      <%= if task_eligible_for_signup?(@task, @campaign) do %>
         <.button
           phx-click={
             JS.push("signup_rider", value: %{task_id: @task.id, rider_id: @current_rider_id})
@@ -264,14 +270,18 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     """
   end
 
-  defp task_eligible_for_signup(task, campaign) do
+  defp task_eligible_for_signup?(task, campaign) do
     # campaign not in past, assigned rider not nil.
     task.assigned_rider == nil && !campaign_in_past(campaign)
   end
 
   # determine if a rider is eligible to "unassign" themselves
-  defp task_eligigle_for_unassign(task, campaign, current_rider_id) do
+  defp task_eligigle_for_unassign?(task, campaign, current_rider_id) do
     task.assigned_rider.id == current_rider_id && !campaign_in_past(campaign)
+  end
+
+  defp campaign_today?(campaign) do
+    LocalizedDateTime.to_date(campaign.delivery_start) == LocalizedDateTime.today()
   end
 
   def initials(name) do

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -192,6 +192,25 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       assert live |> has_element?("#signup-btn-mobile-task-over-#{task.id}")
     end
 
+    test "Rider sees message about texting dispatch if unassigning from a campaign that's today", ctx do
+
+      {:ok, live, html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
+      assert html =~ "Sign up"
+      html = live |> element("#signup-btn-desktop-sign-up-task-#{ctx.task.id}") |> render_click()
+      assert html =~ "Unassign me"
+      assert html =~ "This delivery starts today. If you need to unassign yourself, please also text dispatch to let us know!"
+
+
+      campaign = make_campaign_in_future(ctx.program.id)
+      task = fixture(:task, %{campaign: campaign, rider: nil})
+
+      {:ok, live, html} = live(ctx.conn, ~p"/campaigns/signup/#{campaign.id}/")
+
+      html = live |> element("#signup-btn-desktop-sign-up-task-#{task.id}") |> render_click()
+      assert html =~ "Unassign me"
+      refute html =~ "This delivery starts today. If you need to unassign yourself, please also text dispatch to let us know!"
+    end
+
     test "we see pertinent task information", ctx do
       {:ok, live, html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
 
@@ -249,6 +268,14 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       program_id: program_id,
       delivery_start: LocalizedDateTime.now() |> DateTime.add(-7, :day),
       delivery_end: LocalizedDateTime.now() |> DateTime.add(-7, :day) |> DateTime.add(60, :second)
+    })
+  end
+
+  defp make_campaign_in_future(program_id) do
+    fixture(:campaign, %{
+      program_id: program_id,
+      delivery_start: LocalizedDateTime.now() |> DateTime.add(7, :day),
+      delivery_end: LocalizedDateTime.now() |> DateTime.add(7, :day) |> DateTime.add(60, :second)
     })
   end
 end


### PR DESCRIPTION
This uses the default confirm dialog to add a prompt if the user is cancelling a delivery today. I didn't add the prompt for texting since it's easier to do this as a first pass.

Closes #294 (for now)

## Desktop 
![CleanShot 2024-05-23 at 18 28 33@2x](https://github.com/bikebrigade/dispatch/assets/34720/78fb9f26-2a92-4a43-a172-fbaf404dda18)


## Mobile
<img width="375" alt="image" src="https://github.com/bikebrigade/dispatch/assets/34720/d17aa265-980a-402d-a614-ee5e2f18e951">
