### PR TITLE
Search names across word boundaries only

### DIFF
--- a/lib/bike_brigade/riders/rider_search.ex
+++ b/lib/bike_brigade/riders/rider_search.ex
@@ -230,7 +230,7 @@ defmodule BikeBrigade.Riders.RiderSearch do
   defp apply_filter(%Filter{type: :name, search: search}, query) do
     query
     |> where(
-      fragment("unaccent(?) ilike unaccent(?)", as(:rider).name, ^"%#{search}%") or
+      fragment("unaccent(?) ilike unaccent(?)", as(:rider).name, ^"#{search}%") or
         fragment("unaccent(?) ilike unaccent(?)", as(:rider).name, ^"% #{search}%")
     )
   end
@@ -243,7 +243,7 @@ defmodule BikeBrigade.Riders.RiderSearch do
   defp apply_filter(%Filter{type: :name_or_phone, search: search}, query) do
     query
     |> where(
-      fragment("unaccent(?) ilike unaccent(?)", as(:rider).name, ^"%#{search}%") or
+      fragment("unaccent(?) ilike unaccent(?)", as(:rider).name, ^"#{search}%") or
         fragment("unaccent(?) ilike unaccent(?)", as(:rider).name, ^"% #{search}%") or
         like(as(:rider).phone, ^"%#{search}%")
     )


### PR DESCRIPTION
This fixes an accidental regression from #247 - now searching only looks at start of the name again:

## before
![CleanShot 2024-05-27 at 11 02 37@2x](https://github.com/bikebrigade/dispatch/assets/34720/1cfc258b-fd53-42a3-8a59-8cc216dbb676)

## after
![CleanShot 2024-05-27 at 11 22 23@2x](https://github.com/bikebrigade/dispatch/assets/34720/6eeb87a2-7824-4912-96fc-39e8d33cd030)
