### PR TITLE
fix: reposition flash on mobile.

### DIFF
--- a/lib/bike_brigade_web/core_components.ex
+++ b/lib/bike_brigade_web/core_components.ex
@@ -212,8 +212,8 @@ defmodule BikeBrigadeWeb.CoreComponents do
       phx-mounted={@autoshow && show("##{@id}")}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       class={[
-        "top-0 w-full left-0 right-0 z-50 p-1 m-0 p-3",
-        "fixed hidden md:left-auto md:top-2 md:right-2 md:w-96 md:z-50 md:rounded-lg md:p-3 md:shadow-md md:shadow-zinc-900/5 ring-1",
+        "bottom-0 w-[80%] mx-auto left-0 right-0 z-50 p-1 m-4 p-3",
+        "fixed hidden md:bottom-auto md:m-0 md:left-auto md:top-2 md:right-2 md:w-96 md:z-50 md:rounded-lg md:p-3 md:shadow-md md:shadow-zinc-900/5 ring-1",
         @kind == :info && "bg-emerald-50 text-emerald-800 ring-emerald-500 fill-cyan-900",
         @kind == :warn && "bg-amber-50 text-amber-800 ring-amber-500 fill-amber-900",
         @kind == :error && "bg-rose-50 text-rose-900 shadow-md ring-rose-500 fill-rose-900"


### PR DESCRIPTION
## Describe your changes

closes #346

I was originally overthinking this - adding a new flash library is fairly involved. Why not just move the flash down to within thumbs reach on mobile (and get it out of the way of menu).


If we need to explore future flash libraries, [Flashy](https://github.com/sezaru/flashy) looks good, and so does [LiveToast](https://github.com/srcrip/live_toast). Both involve having to setup JS hooks. 

## Screenshot

https://github.com/bikebrigade/dispatch/assets/12987958/3a354b4c-c102-4d91-ae2c-72bde00e593f


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [n/a] If it is a core feature, I have added tests.
- [n/a] Are there other PRs or Issues that I should link to here?
- [n/a] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
