### PR TITLE
Add: signup_notes, rename rider_notes.

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -638,7 +638,7 @@ defmodule BikeBrigade.Delivery do
 
     task_details =
       for task <- tasks do
-        "Name: #{task.dropoff_name}\nPhone: #{task.dropoff_phone}\nType: #{BikeBrigadeWeb.CampaignHelpers.request_type(task)}\nAddress: #{task.dropoff_location}\nNotes: #{task.rider_notes}"
+        "Name: #{task.dropoff_name}\nPhone: #{task.dropoff_phone}\nType: #{BikeBrigadeWeb.CampaignHelpers.request_type(task)}\nAddress: #{task.dropoff_location}\nNotes: #{task.delivery_instructions}"
       end
       |> Enum.join("\n\n")
 

--- a/lib/bike_brigade/delivery/task.ex
+++ b/lib/bike_brigade/delivery/task.ex
@@ -23,7 +23,8 @@ defmodule BikeBrigade.Delivery.Task do
     :delivery_status,
     :delivery_status_notes,
     :partner_tracking_id,
-    :rider_notes,
+    :delivery_instructions,
+    :signup_notes,
     :assigned_rider_id,
     :campaign_id
   ]
@@ -33,8 +34,8 @@ defmodule BikeBrigade.Delivery.Task do
     :dropoff_location
   ]
   schema "tasks" do
-    # TODO: rename to delivery_instructions
-    field :rider_notes, :string
+    field :delivery_instructions, :string
+    field :signup_notes, :string
 
     field :dropoff_name, :string
     field :dropoff_phone, EctoPhoneNumber.Canadian

--- a/lib/bike_brigade/gsheets_importer.ex
+++ b/lib/bike_brigade/gsheets_importer.ex
@@ -156,7 +156,7 @@ defmodule BikeBrigade.GSheetsImporter do
         dropoff_name: name,
         dropoff_phone: phone,
         dropoff_location: %{address: street, postal: postal},
-        rider_notes: notes,
+        delivery_instructions: notes,
         delivery_status: :pending,
         partner_tracking_id: partner_tracking_id,
         task_items: [%{count: count, item_id: item_id}]
@@ -204,7 +204,7 @@ defmodule BikeBrigade.GSheetsImporter do
         dropoff_name: name,
         dropoff_phone: phone,
         dropoff_location: %{address: street, postal: postal},
-        rider_notes: notes,
+        delivery_instructions: notes,
         delivery_status: :pending,
         partner_tracking_id: partner_tracking_id,
         task_items: task_items

--- a/lib/bike_brigade_web/controllers/campaign_controller.ex
+++ b/lib/bike_brigade_web/controllers/campaign_controller.ex
@@ -46,7 +46,7 @@ defmodule BikeBrigadeWeb.CampaignController do
           task.dropoff_location,
           task.dropoff_phone,
           CampaignHelpers.request_type(task),
-          task.rider_notes
+          task.delivery_instructions
         ]
       end
 

--- a/lib/bike_brigade_web/live/campaign_live/task_form_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/task_form_component.html.heex
@@ -68,7 +68,16 @@
         </.link>
       </div>
 
-      <.input type="textarea" field={{f, :rider_notes}} label="Notes" />
+      <.input
+        type="textarea"
+        field={{f, :delivery_instructions}}
+        label="Delivery Instructions (sent to rider when doing delivery)"
+      />
+      <.input
+        type="textarea"
+        field={{f, :signup_notes}}
+        label="Signup Notes (shown on rider signup - No personal information in this notes, please!)"
+      />
 
       <:actions>
         <.button type="submit" phx-disable-with="Saving...">Save</.button>

--- a/lib/bike_brigade_web/live/campaign_live/tasks_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/tasks_list_component.html.heex
@@ -91,7 +91,7 @@
             <div class="flex flex-row my-2">
               <Heroicons.pencil_square mini class="flex-shrink-0 w-4 h-4 text-gray-500" />
               <div class="mx-1 text-sm leading-5 text-gray-600">
-                <span class="pii"><%= task.rider_notes %></span>
+                <span class="pii"><%= task.delivery_instructions %></span>
               </div>
             </div>
             <div class="flex flex-row my-2">

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -23,6 +23,10 @@
     <:col :let={task} label="Dropoff Neighbourhood">
       <%= Locations.neighborhood(task.dropoff_location) %>
     </:col>
+
+    <:col :let={task} label="Signup Notes">
+      <%= task.signup_notes %>
+    </:col>
     <:action :let={task}>
       <.signup_button
         id="signup-btn-desktop"
@@ -33,7 +37,9 @@
     </:action>
   </.table>
 </section>
+
 <!-- Mobile list of tasks -->
+
 <ul class="flex flex-col text-xs md:hidden">
   <li :for={t <- @tasks} class="w-full mb-8">
     <div class="flex justify-between px-4 py-3 font-bold bg-slate-200">
@@ -42,15 +48,19 @@
     </div>
     <div class="flex flex-col bg-white shadow">
       <div class="flex items-center p-4 py-2 border-b">
-        <span class="pr-2 ">Delivery:</span>
+        <span class="pr-2 font-semibold">Delivery:</span>
         <span class="italic">
           <.get_delivery_size task={t} />
         </span>
       </div>
 
       <div class="flex items-start px-4 py-2 space-x-2 border-b">
-        <span>Dropoff Neighbourhood:</span>
+        <span class="font-semibold">Dropoff Neighbourhood:</span>
         <span><%= Locations.neighborhood(t.dropoff_location) %></span>
+      </div>
+      <div :if={t.signup_notes} class="flex items-start px-4 py-2 space-x-2 border-b">
+        <span class="font-semibold">Signup Notes</span>
+        <span><%= t.signup_notes %></span>
       </div>
 
       <div class="flex flex-col justify-center px-4 py-2 border-b-2">

--- a/lib/bike_brigade_web/live/delivery_live/show.html.heex
+++ b/lib/bike_brigade_web/live/delivery_live/show.html.heex
@@ -228,10 +228,10 @@
               class="relative mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-7"
             >
               <div x-bind:class="{ 'max-h-24': collapsed }" class="overflow-hidden">
-                <%= if is_nil(task.rider_notes) or task.rider_notes=="" do %>
+                <%= if is_nil(task.delivery_instructions) or task.delivery_instructions=="" do %>
                   N/A
                 <% else %>
-                  <%= render_raw(task.rider_notes) %>
+                  <%= render_raw(task.delivery_instructions) %>
                 <% end %>
               </div>
               <div

--- a/lib/bike_brigade_web/live/sms_message_live/index.ex
+++ b/lib/bike_brigade_web/live/sms_message_live/index.ex
@@ -218,7 +218,7 @@ defmodule BikeBrigadeWeb.SmsMessageLive.Index do
 
   defp details_buffer(campaign) do
     for task <- campaign.tasks do
-      "Name: #{task.dropoff_name}\nPhone: #{task.dropoff_phone}\nType: #{request_type(task)}\nAddress: #{task.dropoff_location}\nNotes: #{task.rider_notes}"
+      "Name: #{task.dropoff_name}\nPhone: #{task.dropoff_phone}\nType: #{request_type(task)}\nAddress: #{task.dropoff_location}\nNotes: #{task.delivery_instructions}"
     end
     |> Enum.join("\n\n")
     |> inspect()

--- a/priv/repo/migrations/20240607134749_add_signup_notes_and_rename_rider_notes.exs
+++ b/priv/repo/migrations/20240607134749_add_signup_notes_and_rename_rider_notes.exs
@@ -1,0 +1,11 @@
+defmodule BikeBrigade.Repo.Migrations.AddSignupNotesAndRenameRiderNotes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tasks) do
+       add :signup_notes, :text
+     end
+
+    rename table(:tasks), :rider_notes, to: :delivery_instructions
+  end
+end

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -58,7 +58,7 @@ defmodule BikeBrigade.DeliveryTest do
                Phone: #{task.dropoff_phone}
                Type: 1 #{item_name(task)}
                Address: #{task.dropoff_location}
-               Notes: #{task.rider_notes}
+               Notes: #{task.delivery_instructions}
 
                Directions: #{directions_url}
                """


### PR DESCRIPTION
## Describe your changes

Follow up to the closing of #340 , closes #385

This was done so that we could include signup related information when riders signup for a delivery.
It has also been on the backlog to rename "rider_notes" to "delivery_instructions"

**Delivery Instructions** - To be shown when a rider is doing a delivery. Sometimes contains personal information (ex: "Francis is hearing impaired and might not hear when you ring the doorbell."

**Signup Notes** - Instructions specific to choosing what to sign up for - for example: "{recipient A} is in the same building as {recipient B} - if you can signup for both that would be awesome!

## Screenshot

https://github.com/bikebrigade/dispatch/assets/12987958/8a79cc64-4015-48c7-a0ca-a5708096c932

## Product Update

"Hi Dispatchers! It is now possible to include "rider signup notes—these will show on the page where a rider assigns themselves a specific delivery. This might be useful for letting riders know about co-located deliveries, for example. Please avoid adding personal identifying information into the rider signup notes."

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [x] Are there other PRs or Issues that I should link to here?
- [x] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
