### PR TITLE
fix: remove date filter when fetching campaign_ids

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -275,7 +275,7 @@ defmodule BikeBrigade.Delivery do
   and groups them by campaign ID.
   Written in order to show how "full" a campaign is.
   """
-  def get_total_tasks_and_open_tasks(week \\ nil) do
+  def get_total_tasks_and_open_tasks(start_time \\ nil, end_time \\ nil) do
     query =
       from t in Task,
         as: :task,
@@ -283,12 +283,12 @@ defmodule BikeBrigade.Delivery do
         as: :campaign
 
     query =
-      if week do
-        start_date = LocalizedDateTime.new!(week, ~T[00:00:00])
-        end_date = Date.add(week, 6) |> LocalizedDateTime.new!(~T[23:59:59])
-
+      if start_time && end_time do
         query
-        |> where([campaign: c], c.delivery_start >= ^start_date and c.delivery_start <= ^end_date)
+        |> where(
+          [campaign: c],
+          c.delivery_start >= ^start_time and c.delivery_start <= ^end_time
+        )
       else
         query
       end

--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -204,45 +204,46 @@ defmodule BikeBrigade.Delivery do
   end
 
   defp campaigns_filter(opts) do
-    filter = true
+    public = Keyword.get(opts, :public, nil)
+    campaign_ids = Keyword.get(opts, :campaign_ids, nil)
+    start_date = Keyword.get(opts, :start_date, nil)
+    end_date = Keyword.get(opts, :end_date, nil)
 
-    filter =
-      case Keyword.fetch(opts, :public) do
-        {:ok, true} -> dynamic([program: p], ^filter and p.public == true)
-        {:ok, false} -> dynamic([program: p], ^filter and p.public == false)
-        _ -> filter
-      end
+    true
+    |> filter_public(public)
+    |> filter_campaign_ids(campaign_ids)
+    |> filter_start_date(start_date)
+    |> filter_end_date(end_date)
+  end
 
-    filter =
-      # First we check if we are fetching with campaign_ids
-      # If so, we can ignore start_date and end_date to avoid
-      # cutting off results by the current_week boundary.
-      case Keyword.fetch(opts, :campaign_ids) do
-        {:ok, campaign_ids} when not is_nil(campaign_ids) ->
-          dynamic([campaign: c], ^filter and c.id in ^campaign_ids)
+  defp filter_public(filter, nil), do: filter
 
-        _ ->
-          filter =
-            case Keyword.fetch(opts, :start_date) do
-              {:ok, date} ->
-                date_time = LocalizedDateTime.new!(date, ~T[00:00:00])
-                dynamic([campaign: c], ^filter and c.delivery_start >= ^date_time)
+  defp filter_public(filter, true) do
+    dynamic([program: p], ^filter and p.public == true)
+  end
 
-              _ ->
-                filter
-            end
+  defp filter_public(filter, false) do
+    dynamic([program: p], ^filter and p.public == false)
+  end
 
-          case Keyword.fetch(opts, :end_date) do
-            {:ok, date} ->
-              date_time = LocalizedDateTime.new!(date, ~T[23:59:59])
-              dynamic([campaign: c], ^filter and c.delivery_start <= ^date_time)
+  defp filter_campaign_ids(filter, nil), do: filter
 
-            _ ->
-              filter
-          end
-      end
+  defp filter_campaign_ids(filter, campaign_ids) when is_list(campaign_ids) do
+    dynamic([campaign: c], ^filter and c.id in ^campaign_ids)
+  end
 
-    filter
+  defp filter_start_date(filter, nil), do: filter
+
+  defp filter_start_date(filter, date) do
+    date_time = LocalizedDateTime.new!(date, ~T[00:00:00])
+    dynamic([campaign: c], ^filter and c.delivery_start >= ^date_time)
+  end
+
+  defp filter_end_date(filter, nil), do: filter
+
+  defp filter_end_date(filter, date) do
+    date_time = LocalizedDateTime.new!(date, ~T[23:59:59])
+    dynamic([campaign: c], ^filter and c.delivery_start <= ^date_time)
   end
 
   @doc """

--- a/lib/bike_brigade_web/live/campaign_signup_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/index.ex
@@ -20,6 +20,8 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
     campaign_filter = {:current_week, current_week}
 
     campaigns = fetch_campaigns(campaign_filter)
+    start_date = LocalizedDateTime.new!(current_week, ~T[00:00:00])
+    end_date = Date.add(current_week, 6) |> LocalizedDateTime.new!(~T[23:59:59])
 
     {:ok,
      socket
@@ -27,7 +29,10 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
      |> assign(:page_title, "Delivery Sign Up")
      |> assign(:current_week, current_week)
      |> assign(:campaign_filter, campaign_filter)
-     |> assign(:campaign_task_counts, Delivery.get_total_tasks_and_open_tasks(current_week))
+     |> assign(
+       :campaign_task_counts,
+       Delivery.get_total_tasks_and_open_tasks(start_date, end_date)
+     )
      |> assign(:showing_urgent_campaigns, false)
      |> assign(:campaigns, campaigns)}
   end
@@ -37,10 +42,17 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
     campaign_filter = {:campaign_ids, campaign_ids}
     campaigns = fetch_campaigns(campaign_filter)
 
+    start_date = LocalizedDateTime.now()
+    end_date = Date.add(start_date, 2) |> LocalizedDateTime.new!(~T[23:59:59])
+
     {:noreply,
      socket
      |> assign(:campaigns, campaigns)
      |> assign(:campaign_filter, campaign_filter)
+     |> assign(
+       :campaign_task_counts,
+       Delivery.get_total_tasks_and_open_tasks(start_date, end_date)
+     )
      |> assign(:showing_urgent_campaigns, true)}
   end
 

--- a/lib/bike_brigade_web/live/campaign_signup_live/index.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/index.html.heex
@@ -43,7 +43,7 @@
 </nav>
 
 <%= if @campaigns != [] do %>
-  <div :if={@showing_urgent_campaigns} class="bg-red-300 p-2 rounded bg-opacity-40">
+  <div :if={@showing_urgent_campaigns} class="bg-red-300 p-2 lg:mb-4 rounded bg-opacity-40">
     These deliveries need riders in the next 48 hours:
   </div>
 

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -205,7 +205,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       campaign = make_campaign_in_future(ctx.program.id)
       task = fixture(:task, %{campaign: campaign, rider: nil})
 
-      {:ok, live, html} = live(ctx.conn, ~p"/campaigns/signup/#{campaign.id}/")
+      {:ok, live, _html} = live(ctx.conn, ~p"/campaigns/signup/#{campaign.id}/")
 
       html = live |> element("#signup-btn-desktop-sign-up-task-#{task.id}") |> render_click()
       assert html =~ "Unassign me"

--- a/test/bike_brigade_web/live/rider_home_live_test.exs
+++ b/test/bike_brigade_web/live/rider_home_live_test.exs
@@ -51,7 +51,9 @@ defmodule BikeBrigadeWeb.RiderHomeLiveTest do
         program: program,
         campaign: campaign,
         campaign2: campaign2,
-        campaign3: campaign3
+        campaign3: campaign3,
+        campaign4: campaign4,
+        campaign_in_50_hours: campaign_in_50_hours
       })
     end
 
@@ -76,6 +78,20 @@ defmodule BikeBrigadeWeb.RiderHomeLiveTest do
 
       expected_redirect =
         ~p"/campaigns/signup?campaign_ids[]=#{ctx.campaign.id}&campaign_ids[]=#{ctx.campaign2.id}&campaign_ids[]=#{ctx.campaign3.id}"
+
+      # the cta button should link to only the relevant campaigns.
+      assert html
+             |> Floki.parse_fragment!()
+             |> Floki.find("#urgent-campaigns-signup-btn")
+             |> Floki.attribute("href") == [expected_redirect]
+
+      # let's visit the campaigns and ensure that the right ones render.
+      {:ok, _live, html} = live(ctx.conn, expected_redirect)
+      assert html =~ "campaign-#{ctx.campaign.id}"
+      assert html =~ "campaign-#{ctx.campaign2.id}"
+      assert html =~ "campaign-#{ctx.campaign3.id}"
+      refute html =~ "campaign-#{ctx.campaign4.id}"
+      refute html =~ "campaign-#{ctx.campaign_in_50_hours.id}"
     end
 
     test "it shows rider's itinerary of deliveries for today, with a sign up button", ctx do


### PR DESCRIPTION
fixes #369 

Here is a video demonstrating the bug on a sunday, as well as the fix:


https://github.com/bikebrigade/dispatch/assets/12987958/28951629-c34f-4149-b913-9aa3e59c1f49



## Describe your changes

- when list_campaigns is called with an option of `campaign_ids`, we disable filtering by start/end date.

@mveytsman any ideas on how I could write a test for this that simulates that it's a sunday locally and the campaigns in question are on a monday (without changing the system under test?)


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
