### PR TITLE
Fix bug in plug pipelines

### DIFF
--- a/lib/bike_brigade_web/components/layouts.ex
+++ b/lib/bike_brigade_web/components/layouts.ex
@@ -77,7 +77,7 @@ defmodule BikeBrigadeWeb.Layouts do
           My Profile
         </.sidebar_link>
 
-        <.sidebar_link selected={@current_page == :logout} href={~p"/logout"} method="post">
+        <.sidebar_link selected={@current_page == :logout} href={~p"/logout"} method="delete">
           <:icon>
             <Heroicons.arrow_left_on_rectangle solid />
           </:icon>

--- a/lib/bike_brigade_web/endpoint.ex
+++ b/lib/bike_brigade_web/endpoint.ex
@@ -48,6 +48,11 @@ defmodule BikeBrigadeWeb.Endpoint do
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+
   plug Plug.MethodOverride
   plug Plug.Head
   plug Plug.Session, @session_options

--- a/lib/bike_brigade_web/router.ex
+++ b/lib/bike_brigade_web/router.ex
@@ -27,15 +27,7 @@ defmodule BikeBrigadeWeb.Router do
     plug :get_user_from_session
   end
 
-  pipeline :parse_request do
-    plug Plug.Parsers,
-      parsers: [:urlencoded, :multipart, :json],
-      pass: ["*/*"],
-      json_decoder: Phoenix.json_library()
-  end
-
   pipeline :browser do
-    plug :parse_request
     plug :accepts, ["html"]
     plug :sessions
     plug :fetch_live_flash
@@ -46,7 +38,6 @@ defmodule BikeBrigadeWeb.Router do
   end
 
   pipeline :api do
-    plug :parse_request
     plug :accepts, ["json"]
   end
 
@@ -110,7 +101,7 @@ defmodule BikeBrigadeWeb.Router do
       live "/leaderboard", StatsLive.Leaderboard, :show
     end
 
-    post "/logout", Authentication, :logout
+    delete "/logout", Authentication, :logout
   end
 
   scope "/", BikeBrigadeWeb do


### PR DESCRIPTION
Fix a long-standing bug with how our plug pipelines were organized.

This prevented the MethodOverride plug from working, which allows us to make links that have a `DELETE` method for example.

Also update the logout button to use delete.

## Describe your changes

<!-- Please add a link to a ticket if relevant: eg: "closes #340" -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [n/a] If it is a core feature, I have added tests.
- [x] Are there other PRs or Issues that I should link to here?
- [n/a] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
