### PR TITLE
config: support APP_TZ to configure time zone

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,6 +9,9 @@ import Config
 
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
+config :bike_brigade, BikeBrigade.LocalizedDateTime,
+  timezone: System.get_env("APP_TZ", "America/Toronto")
+
 config :bike_brigade,
   ecto_repos: [BikeBrigade.Repo]
 

--- a/lib/bike_brigade/localized_date_time.ex
+++ b/lib/bike_brigade/localized_date_time.ex
@@ -1,12 +1,14 @@
 defmodule BikeBrigade.LocalizedDateTime do
-  @timezone "America/Toronto"
+  defp timezone() do
+    Application.get_env(:bike_brigade, __MODULE__)[:timezone]
+  end
 
   def localize(%DateTime{} = datetime) do
-    DateTime.shift_zone!(datetime, @timezone)
+    DateTime.shift_zone!(datetime, timezone())
   end
 
   def localize(%NaiveDateTime{} = datetime) do
-    DateTime.from_naive!(datetime, @timezone)
+    DateTime.from_naive!(datetime, timezone())
   end
 
   def now() do
@@ -20,11 +22,11 @@ defmodule BikeBrigade.LocalizedDateTime do
   end
 
   def new(date, time) do
-    DateTime.new(date, time, @timezone)
+    DateTime.new(date, time, timezone())
   end
 
   def new!(date, time) do
-    DateTime.new!(date, time, @timezone)
+    DateTime.new!(date, time, timezone())
   end
 
   def to_date(datetime) do


### PR DESCRIPTION
## Describe your changes

Currently, the app has "America/Toronto" hardcoded as the time zone in LocalizedDateTime. That makes it harder to use in other zones.

To help that, support APP_TZ in the environment. If set, use that value instead. The default is still America/Toronto.

Updates #381

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
