### PR TITLE
.github: bump CI elixir and OTP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-elixir@v1
         with:
-          elixir-version: '1.14.2'
-          otp-version: '25'
+          elixir-version: '1.15'
+          otp-version: '26'
 
       - name: Cache Elixir deps
         id: elixir-deps-cache


### PR DESCRIPTION
## Describe your changes

Should fix these CI warnings:

the underscored variable "_t" is used after being set

Ref elixir-lang/elixir#12262

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
