### PR TITLE
config: support DATABASE_URL when testing

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,17 +2,22 @@ import Config
 
 config :bike_brigade, :environment, :test
 
-# Configure your database
-#
-# The MIX_TEST_PARTITION environment variable can be used
-# to provide built-in test partitioning in CI environment.
-# Run `mix help test` for more information.
-config :bike_brigade, BikeBrigade.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "bike_brigade_test#{System.get_env("MIX_TEST_PARTITION")}",
-  hostname: "localhost",
-  pool: Ecto.Adapters.SQL.Sandbox
+database_url =
+  System.get_env("DATABASE_URL")
+
+if database_url do
+  config :bike_brigade, BikeBrigade.Repo, url: database_url, pool: Ecto.Adapters.SQL.Sandbox
+else
+  # The MIX_TEST_PARTITION environment variable can be used
+  # to provide built-in test partitioning in CI environment.
+  # Run `mix help test` for more information.
+  config :bike_brigade, BikeBrigade.Repo,
+    username: "postgres",
+    password: "postgres",
+    database: "bike_brigade_test#{System.get_env("MIX_TEST_PARTITION")}",
+    hostname: "localhost",
+    pool: Ecto.Adapters.SQL.Sandbox
+end
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.


### PR DESCRIPTION
## Describe your changes

I run postgres locally but without postgis. It would be nice to run the postgis docker image on another port/etc and point to that.

To help that, support DATABASE_URL when testing. If not set the database config is unchanged.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
