### PR TITLE
.github,etc: enforce `mix format` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
         run: mix deps.get
       - name: Compile
         run: mix compile
+      - name: Check Elixir code formatting
+        run: mix format --check-formatted
       - name: Install JS dependencies
         run: npm install --prefix=assets
       - name: Compile assets

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ If you wish to run a specific test you can provide a file and optionally a line 
 scripts/test path/to/test.exs:LINENUMBER
 ```
 
+### Code formatting
+
+Format code with
+
+```
+scripts/format
+```
+
+There is probably a way to set up your editor to run `scripts/format` on save. [This article](https://medium.com/@rviragh/all-elixir-coders-should-autoformat-on-save-heres-how-ae094dd7af82) may help in a VS Code context.
+
+You can also add `mix format --check-formatted` to a [Git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to have git automatically error on `git commit` if formatting needs to be applied.
+
+Note: similar to having the Elixir language server available in your editor you may need to launch your editor from within `nix-shell` or otherwise make sure your editor can find/run `scripts/format`.
+
 ### Updating nix dependencies
 [niv](https://github.com/nmattia/niv) is used to ensure everyone is using the same version of nixpkgs.
 To update the nixpkgs version run:

--- a/config/config.exs
+++ b/config/config.exs
@@ -68,10 +68,9 @@ config :phoenix, :json_library, Jason
 config :geo_postgis,
   json_library: Jason
 
-config :bike_brigade, BikeBrigade.Tasks.MailchimpImporter,
-  list_id: {:system, "MAILCHIMP_LIST_ID"}
+config :bike_brigade, BikeBrigade.Tasks.MailchimpImporter, list_id: {:system, "MAILCHIMP_LIST_ID"}
 
-  config :bike_brigade, BikeBrigade.Tasks.MailchimpAttributesSync,
+config :bike_brigade, BikeBrigade.Tasks.MailchimpAttributesSync,
   list_id: {:system, "MAILCHIMP_LIST_ID"}
 
 # We use the same phone number for our authentication and regular messaging by they are configurable separately for now
@@ -80,10 +79,12 @@ config :bike_brigade, BikeBrigade.Messaging,
   new_outbound_number: {:system, "NEW_PHONE_NUMBER", default: "647-555-5555"},
   inbound_numbers: {:system, "INBOUND_NUMBERS", default: "647-555-5555"}
 
-config :bike_brigade, BikeBrigade.AuthenticationMessenger, phone_number: {:system, "PHONE_NUMBER", default: "647-555-5555"}
+config :bike_brigade, BikeBrigade.AuthenticationMessenger,
+  phone_number: {:system, "PHONE_NUMBER", default: "647-555-5555"}
 
 # Config our google clients
-config :bike_brigade, BikeBrigade.GoogleMaps, api_key: {:system, "GOOGLE_MAPS_API_KEY", default: ""}
+config :bike_brigade, BikeBrigade.GoogleMaps,
+  api_key: {:system, "GOOGLE_MAPS_API_KEY", default: ""}
 
 # Set slack channel IDs for messaging
 config :bike_brigade, BikeBrigade.Messaging.Slack.Operations,

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -79,7 +79,7 @@
     <.header>
       Delivery photos
       <:subtitle>
-       <%= @campaign.program.photo_description %>
+        <%= @campaign.program.photo_description %>
       </:subtitle>
     </.header>
     <div class="grid grid-cols-3 gap-4 mt-4">

--- a/lib/bike_brigade_web/live/program_live/form_component.ex
+++ b/lib/bike_brigade_web/live/program_live/form_component.ex
@@ -107,6 +107,7 @@ defmodule BikeBrigadeWeb.ProgramLive.FormComponent do
           program
           |> Delivery.Program.changeset(%{photos: photos})
       )
+
     {:noreply, assign(socket, :changeset, changeset)}
   end
 

--- a/lib/bike_brigade_web/live/program_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/program_live/form_component.html.heex
@@ -170,7 +170,10 @@
             </figcaption>
           </figure>
         </div>
-        <div class="flex justify-center px-6 py-10 mt-2 border border-dashed rounded-lg border-gray-900/25" phx-drop-target={@uploads.photos.ref}>
+        <div
+          class="flex justify-center px-6 py-10 mt-2 border border-dashed rounded-lg border-gray-900/25"
+          phx-drop-target={@uploads.photos.ref}
+        >
           <div class="text-center">
             <Heroicons.photo solid class="w-12 h-12 mx-auto text-gray-300" />
 

--- a/priv/repo/.formatter.exs
+++ b/priv/repo/.formatter.exs
@@ -1,4 +1,4 @@
 [
   import_deps: [:ecto_sql],
-  inputs: ["/**/*.{ex,exs}"],
+  inputs: ["**/*.{ex,exs}"]
 ]

--- a/priv/repo/migrations/20220811214421_rider_deleted_at.exs
+++ b/priv/repo/migrations/20220811214421_rider_deleted_at.exs
@@ -2,7 +2,6 @@ defmodule BikeBrigade.Repo.Migrations.RiderDeletedAt do
   use Ecto.Migration
   # import BikeBrigade.MigrationUtils
 
-
   def change do
     alter table(:riders) do
       add :deleted_at, :utc_datetime, default: nil

--- a/priv/repo/migrations/20230210130847_load_sql_riders_latest_campaigns.exs
+++ b/priv/repo/migrations/20230210130847_load_sql_riders_latest_campaigns.exs
@@ -1,7 +1,14 @@
 defmodule BikeBrigade.Repo.Migrations.RidersLatestCampaigns do
   use Ecto.Migration
+
   def up do
-    sql = Path.join(:code.priv_dir(:bike_brigade), "repo/sql/riders_latest_campaigns_20230210130847.sql") |> File.read!()
+    sql =
+      Path.join(
+        :code.priv_dir(:bike_brigade),
+        "repo/sql/riders_latest_campaigns_20230210130847.sql"
+      )
+      |> File.read!()
+
     execute(sql)
   end
 

--- a/priv/repo/migrations/20230210130852_load_sql_rider_stats.exs
+++ b/priv/repo/migrations/20230210130852_load_sql_rider_stats.exs
@@ -1,7 +1,11 @@
 defmodule BikeBrigade.Repo.Migrations.RiderStats do
   use Ecto.Migration
+
   def up do
-    sql = Path.join(:code.priv_dir(:bike_brigade), "repo/sql/rider_stats_20230210130852.sql") |> File.read!()
+    sql =
+      Path.join(:code.priv_dir(:bike_brigade), "repo/sql/rider_stats_20230210130852.sql")
+      |> File.read!()
+
     execute(sql)
   end
 

--- a/priv/repo/migrations/20230210130857_load_sql_programs_latest_campaigns.exs
+++ b/priv/repo/migrations/20230210130857_load_sql_programs_latest_campaigns.exs
@@ -1,7 +1,14 @@
 defmodule BikeBrigade.Repo.Migrations.ProgramsLatestCampaigns do
   use Ecto.Migration
+
   def up do
-    sql = Path.join(:code.priv_dir(:bike_brigade), "repo/sql/programs_latest_campaigns_20230210130857.sql") |> File.read!()
+    sql =
+      Path.join(
+        :code.priv_dir(:bike_brigade),
+        "repo/sql/programs_latest_campaigns_20230210130857.sql"
+      )
+      |> File.read!()
+
     execute(sql)
   end
 

--- a/priv/repo/migrations/20230210130901_load_sql_locations_neighborhoods.exs
+++ b/priv/repo/migrations/20230210130901_load_sql_locations_neighborhoods.exs
@@ -1,7 +1,14 @@
 defmodule BikeBrigade.Repo.Migrations.LocationsNeighborhoods do
   use Ecto.Migration
+
   def up do
-    sql = Path.join(:code.priv_dir(:bike_brigade), "repo/sql/locations_neighborhoods_20230210130901.sql") |> File.read!()
+    sql =
+      Path.join(
+        :code.priv_dir(:bike_brigade),
+        "repo/sql/locations_neighborhoods_20230210130901.sql"
+      )
+      |> File.read!()
+
     execute(sql)
   end
 

--- a/priv/repo/migrations/20230210130937_load_sql_campaign_stats.exs
+++ b/priv/repo/migrations/20230210130937_load_sql_campaign_stats.exs
@@ -1,7 +1,11 @@
 defmodule BikeBrigade.Repo.Migrations.CampaignStats do
   use Ecto.Migration
+
   def up do
-    sql = Path.join(:code.priv_dir(:bike_brigade), "repo/sql/campaign_stats_20230210130937.sql") |> File.read!()
+    sql =
+      Path.join(:code.priv_dir(:bike_brigade), "repo/sql/campaign_stats_20230210130937.sql")
+      |> File.read!()
+
     execute(sql)
   end
 

--- a/priv/repo/migrations/20230210130951_load_sql_campaigns_latest_sms_messages.exs
+++ b/priv/repo/migrations/20230210130951_load_sql_campaigns_latest_sms_messages.exs
@@ -1,7 +1,14 @@
 defmodule BikeBrigade.Repo.Migrations.CampaignsLatestSmsMessages do
   use Ecto.Migration
+
   def up do
-    sql = Path.join(:code.priv_dir(:bike_brigade), "repo/sql/campaigns_latest_sms_messages_20230210130951.sql") |> File.read!()
+    sql =
+      Path.join(
+        :code.priv_dir(:bike_brigade),
+        "repo/sql/campaigns_latest_sms_messages_20230210130951.sql"
+      )
+      |> File.read!()
+
     execute(sql)
   end
 

--- a/priv/repo/migrations/20240314201721_add_campaigns_riders_rider_signed_up_flag.exs
+++ b/priv/repo/migrations/20240314201721_add_campaigns_riders_rider_signed_up_flag.exs
@@ -1,5 +1,6 @@
 defmodule BikeBrigade.Repo.Migrations.AddCampaignsRidersRiderSignedUpFlag do
   use Ecto.Migration
+
   def change do
     alter table(:campaigns_riders) do
       add :rider_signed_up, :boolean, default: false

--- a/priv/repo/migrations/20240607134749_add_signup_notes_and_rename_rider_notes.exs
+++ b/priv/repo/migrations/20240607134749_add_signup_notes_and_rename_rider_notes.exs
@@ -3,8 +3,8 @@ defmodule BikeBrigade.Repo.Migrations.AddSignupNotesAndRenameRiderNotes do
 
   def change do
     alter table(:tasks) do
-       add :signup_notes, :text
-     end
+      add :signup_notes, :text
+    end
 
     rename table(:tasks), :rider_notes, to: :delivery_instructions
   end

--- a/scripts/format
+++ b/scripts/format
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$(dirname "$0")/utils.sh"
+
+set -e
+
+wrap_nix_shell "mix format"

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -232,7 +232,10 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       {:ok, live, html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
       refute html =~ "Delivery photos"
 
-      Delivery.update_program(ctx.program, %{photos: ["https://example.com/photo.jpg"], photo_description: "a typical meal"})
+      Delivery.update_program(ctx.program, %{
+        photos: ["https://example.com/photo.jpg"],
+        photo_description: "a typical meal"
+      })
 
       {:ok, live, html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
       assert html =~ "Delivery photos"


### PR DESCRIPTION
## Describe your changes

Consistent and automated code formatting can make it much easier to work with a codebase.

In #396 a run of `mix format` with args was done.

This change enforces use of `mix format` in CI and adds a note to the README about how to format. A hint for editor and git config is also added.

The existing formatter config is fixed up so just running `mix format` should do the right thing.

Updates #394

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
