### PR TITLE
reverse campaign order lists.

### DIFF
--- a/lib/bike_brigade_web/live/campaign_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_live/index.ex
@@ -84,7 +84,6 @@ defmodule BikeBrigadeWeb.CampaignLive.Index do
     )
     |> Enum.reverse()
     |> Utils.ordered_group_by(&LocalizedDateTime.to_date(&1.delivery_start))
-    |> Enum.reverse()
   end
 
   attr :campaign, Campaign, required: true

--- a/lib/bike_brigade_web/live/campaign_signup_live/index.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/index.ex
@@ -119,7 +119,6 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Index do
     )
     |> Enum.reverse()
     |> Utils.ordered_group_by(&LocalizedDateTime.to_date(&1.delivery_start))
-    |> Enum.reverse()
   end
 
   defp fetch_campaigns({:campaign_ids, campaign_ids}) do


### PR DESCRIPTION
## Describe your changes

Fixes #421 

![signup page](https://github.com/user-attachments/assets/3195f905-7714-4269-838b-1ee6a0245681)
![sorting change](https://github.com/user-attachments/assets/6c7ae03e-3910-423d-ba88-573527b0c232)

## Product update:

"The campaign list page will now sort campaigns by soonest-to-latest both for dispatchers and the rider sign up page".

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [n/a] If it is a core feature, I have added tests.
- [n/a] Are there other PRs or Issues that I should link to here?
- [x] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above:
