### PR TITLE
Ns/415 identify novice riders

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -454,9 +454,9 @@ defmodule BikeBrigade.Delivery do
             delivery_url_token: cr.token
           }
       )
-      |> Repo.preload(:location)
+      |> Repo.preload([:location, :total_stats])
 
-    # Does a nested preload to get tasks' assigned riders without doing an extra db query
+      # Does a nested preload to get tasks' assigned riders without doing an extra db query
     tasks = Repo.preload(all_tasks, assigned_rider: fn _ -> all_riders end)
 
     riders = Repo.preload(all_riders, assigned_tasks: fn _ -> all_tasks end)

--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -456,7 +456,7 @@ defmodule BikeBrigade.Delivery do
       )
       |> Repo.preload([:location, :total_stats])
 
-      # Does a nested preload to get tasks' assigned riders without doing an extra db query
+    # Does a nested preload to get tasks' assigned riders without doing an extra db query
     tasks = Repo.preload(all_tasks, assigned_rider: fn _ -> all_riders end)
 
     riders = Repo.preload(all_riders, assigned_tasks: fn _ -> all_tasks end)

--- a/lib/bike_brigade_web/helpers/campaign_helpers.ex
+++ b/lib/bike_brigade_web/helpers/campaign_helpers.ex
@@ -128,4 +128,10 @@ defmodule BikeBrigadeWeb.CampaignHelpers do
   defp print_item(task_item) do
     "#{task_item.count} #{Inflex.inflect(task_item.item.name, task_item.count)}"
   end
+
+  def novice_participant?(%Rider{total_stats: nil}), do: true
+  def novice_participant?(%Rider{total_stats: %{campaign_count: nil}}), do: true
+  def novice_participant?(%Rider{total_stats: %{campaign_count: campaign_count}}) when campaign_count < 5, do: true
+  def novice_participant?(%Rider{total_stats: %{campaign_count: campaign_count}}) when campaign_count >= 5, do: false
+
 end

--- a/lib/bike_brigade_web/helpers/campaign_helpers.ex
+++ b/lib/bike_brigade_web/helpers/campaign_helpers.ex
@@ -131,7 +131,12 @@ defmodule BikeBrigadeWeb.CampaignHelpers do
 
   def novice_participant?(%Rider{total_stats: nil}), do: true
   def novice_participant?(%Rider{total_stats: %{campaign_count: nil}}), do: true
-  def novice_participant?(%Rider{total_stats: %{campaign_count: campaign_count}}) when campaign_count < 5, do: true
-  def novice_participant?(%Rider{total_stats: %{campaign_count: campaign_count}}) when campaign_count >= 5, do: false
 
+  def novice_participant?(%Rider{total_stats: %{campaign_count: campaign_count}})
+      when campaign_count < 5,
+      do: true
+
+  def novice_participant?(%Rider{total_stats: %{campaign_count: campaign_count}})
+      when campaign_count >= 5,
+      do: false
 end

--- a/lib/bike_brigade_web/helpers/campaign_helpers.ex
+++ b/lib/bike_brigade_web/helpers/campaign_helpers.ex
@@ -4,6 +4,8 @@ defmodule BikeBrigadeWeb.CampaignHelpers do
 
   alias BikeBrigade.LocalizedDateTime
 
+  @novice_campaign_threshold 5
+
   def task_assigned?(task) do
     task.assigned_rider != nil
   end
@@ -133,10 +135,10 @@ defmodule BikeBrigadeWeb.CampaignHelpers do
   def novice_participant?(%Rider{total_stats: %{campaign_count: nil}}), do: true
 
   def novice_participant?(%Rider{total_stats: %{campaign_count: campaign_count}})
-      when campaign_count < 5,
+      when campaign_count < @novice_campaign_threshold,
       do: true
 
   def novice_participant?(%Rider{total_stats: %{campaign_count: campaign_count}})
-      when campaign_count >= 5,
+      when campaign_count >= @novice_campaign_threshold,
       do: false
 end

--- a/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
@@ -67,6 +67,20 @@
                 class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500 justify-self-end"
               />
             <% end %>
+            <%= if novice_participant?(rider) do %>
+              <.with_tooltip>
+                <Heroicons.star
+                  mini
+                  class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500 justify-self-end"
+                />
+                <:tooltip>
+                  <div class="w-20">
+                    Novice rider
+                  </div>
+                </:tooltip>
+              </.with_tooltip>
+            <% end %>
+
             <%= if has_notes?(rider) do %>
               <Heroicons.pencil_square mini class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500" />
             <% end %>
@@ -98,6 +112,7 @@
                 </div>
               </div>
             <% end %>
+            
             <%= if Enum.count(rider.assigned_tasks) > 0 do %>
               <%= for task <- rider.assigned_tasks do %>
                 <div class="flex flex-row my-2">

--- a/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
@@ -112,7 +112,6 @@
                 </div>
               </div>
             <% end %>
-            
             <%= if Enum.count(rider.assigned_tasks) > 0 do %>
               <%= for task <- rider.assigned_tasks do %>
                 <div class="flex flex-row my-2">

--- a/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
@@ -74,8 +74,8 @@
                   class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500 justify-self-end"
                 />
                 <:tooltip>
-                  <div class="w-20">
-                    Novice rider
+                  <div class="w-18">
+                    New rider (less than 5 campaigns)
                   </div>
                 </:tooltip>
               </.with_tooltip>


### PR DESCRIPTION
## Describe your changes

https://github.com/bikebrigade/dispatch/issues/415

Feature added to easily identify novice riders (those with fewer than 5 deliveries) on the campaign page using Star icon as an indicator.
![star_icon_for_novice_riders](https://github.com/user-attachments/assets/f1c967f4-6dbe-4036-ae70-d32ec4c770b6)

## Checklist before requesting a review

- [x] I have performed a self-review of my code - Yes
- [ ] If it is a core feature, I have added tests. - No
- [ ] Are there other PRs or Issues that I should link to here? - No
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above. 
