### PR TITLE
Add: migration for missing column in prod.

### DIFF
--- a/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
+++ b/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
@@ -2,11 +2,8 @@ defmodule BikeBrigade.Repo.Migrations.AddCreatedByIdToBanners do
   use Ecto.Migration
 
   def change do
-    # Only add the column if it doesn't exist
-    unless column_exists?(:banners, :created_by_id) do
-      alter table(:banners) do
-        add :created_by_id, references(:users), null: true
-      end
+    alter table(:banners) do
+      add_if_not_exists :created_by_id, references(:users), null: true
     end
   end
 end

--- a/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
+++ b/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
@@ -2,8 +2,14 @@ defmodule BikeBrigade.Repo.Migrations.AddCreatedByIdToBanners do
   use Ecto.Migration
 
   def change do
-    alter table(:banners) do
-      add_if_not_exists :created_by_id, references(:users), null: true
+    drop_if_exists table(:banners)
+
+    create table(:banners) do
+      add :message, :text
+      add :created_by_id, references(:users)
+      add :turn_on_at, :utc_datetime
+      add :turn_off_at, :utc_datetime
+      add :enabled, :boolean
     end
   end
 end

--- a/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
+++ b/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
@@ -1,0 +1,11 @@
+defmodule BikeBrigade.Repo.Migrations.AddCreatedByIdToBanners do
+  use Ecto.Migration
+
+  def change do
+    alter table(:banners) do
+      add :created_by_id, references(:users), null: true
+    end
+
+    create index(:banners, [:created_by_id])
+  end
+end

--- a/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
+++ b/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
@@ -2,8 +2,11 @@ defmodule BikeBrigade.Repo.Migrations.AddCreatedByIdToBanners do
   use Ecto.Migration
 
   def change do
-    alter table(:banners) do
-      add :created_by_id, references(:users), null: true
+    # Only add the column if it doesn't exist
+    unless column_exists?(:banners, :created_by_id) do
+      alter table(:banners) do
+        add :created_by_id, references(:users), null: true
+      end
     end
   end
 end

--- a/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
+++ b/priv/repo/migrations/20250825010647_add_created_by_id_to_banners.exs
@@ -5,7 +5,5 @@ defmodule BikeBrigade.Repo.Migrations.AddCreatedByIdToBanners do
     alter table(:banners) do
       add :created_by_id, references(:users), null: true
     end
-
-    create index(:banners, [:created_by_id])
   end
 end


### PR DESCRIPTION
## Describe your changes

running into this error on the `/banners` page:

```
[Postgrex.Error](https://app.honeybadger.io/projects/79471/faults/122939292): ERROR 42703 (undefined_column) column b0.created_by_id does not exist
   query: SELECT b0."id", b0."message", b0."turn_on_at", b0."turn_off_at", b0."enabled", b0."created_by_id" FROM "banners" AS b0
   hint:...
Backtrace:
line 61 of lib/bike_brigade_web/live/banner_live/index.ex: list_banners/0
line 14 of lib/bike_brigade_web/live/banner_live/index.ex: mount/3
Project
Bike Brigade
Environment
prod
```

I originally tried creating a migration just to add the missing column. However, the column exists in CI and so CI fails. I figured the fastest way to get around this would be to drop the entire table since there's no data in it yet and then stand it up again.
