### PR TITLE
Increase database timeouts

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -97,7 +97,11 @@ case config_env() do
     config :bike_brigade, BikeBrigade.Repo,
       url: database_url,
       ssl: false,
-      pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
+      pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+      queue_target: 5_000,
+      queue_interval: 2_000,
+      timeout: 60_000,
+      connect_timeout: 60_000
 
     secret_key_base =
       System.get_env("SECRET_KEY_BASE") ||


### PR DESCRIPTION
## Describe your changes

This increases the database timeouts as we have had a lot of queries timing out causing cascading failures. It's not an ideal solution as we shouldn't have long running queries in prod, but this is a good defensive fix considering I will be away next week
