### PR TITLE
Fix channel selector

### DIFF
--- a/lib/bike_brigade_web/live/program_live/form_component.ex
+++ b/lib/bike_brigade_web/live/program_live/form_component.ex
@@ -202,7 +202,7 @@ defmodule BikeBrigadeWeb.ProgramLive.FormComponent do
 
       channels
       |> Enum.filter(fn channel ->
-        String.starts_with?(channel["name"], "campaigns") || channel["name"] == "api-playground"
+        String.starts_with?(channel["name"], "campaign") || channel["name"] == "api-playground"
       end)
       |> Enum.map(fn channel ->
         {channel["name"], channel["id"]}


### PR DESCRIPTION
Some of our slack channels are `campaign-foo` and some are `campaigns-foo`. Ooops