### PR TITLE
Update capacity labels and add help text

### DIFF
--- a/lib/bike_brigade_web/core_components.ex
+++ b/lib/bike_brigade_web/core_components.ex
@@ -382,6 +382,9 @@ defmodule BikeBrigadeWeb.CoreComponents do
         <option :if={@prompt}>{@prompt}</option>
         {Phoenix.HTML.Form.options_for_select(@options, @value)}
       </select>
+      <p :if={@help_text} class="mt-2 text-sm text-gray-500">
+        {@help_text}
+      </p>
       <.error :for={msg <- @errors}>{msg}</.error>
     </div>
     """

--- a/lib/bike_brigade_web/live/rider_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/rider_live/form_component.html.heex
@@ -56,7 +56,12 @@
       type="select"
       field={f[:capacity]}
       label="Capacity"
-      options={[{"Small", :small}, {"Medium", :medium}, {"Large", :large}]}
+      options={[
+        {"Small (backpack)", :small},
+        {"Medium (rack/panniers)", :medium},
+        {"Large (trailer)", :large}
+      ]}
+      help_text="Capacities are examples, and if your configuration is different use your judgement."
     />
 
     <.live_component


### PR DESCRIPTION
Riders can edit their capacity in their profile. Adds some clarification to small/medium/large
<img width="1128" height="184" alt="CleanShot 2026-01-08 at 10 53 39@2x" src="https://github.com/user-attachments/assets/fab0381b-11a5-43f0-92fd-bedb81b19766" />
<img width="1082" height="236" alt="CleanShot 2026-01-08 at 10 53 35@2x" src="https://github.com/user-attachments/assets/6035f52d-45ba-46d2-bec2-49aee010c0d8" />
