### PR TITLE
Persist rider search filters in URL query params

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ The application follows Phoenix context patterns with these main domains:
 ## Development Notes
 
 ### Code Style
-- Always run `scripts/format` before committing changes
+- **ALWAYS run `scripts/format` before committing changes or presenting final code**
 
 ### Database
 The application uses PostgreSQL with several extensions including PostGIS for geographic data, fuzzystrmatch for fuzzy matching, and unaccent for text processing.

--- a/lib/bike_brigade_web/live/rider_live/index.ex
+++ b/lib/bike_brigade_web/live/rider_live/index.ex
@@ -196,7 +196,8 @@ defmodule BikeBrigadeWeb.RiderLive.Index do
           nil
       end
 
-    new_filters = socket.assigns.rider_search.filters ++ if(new_filter, do: [new_filter], else: [])
+    new_filters =
+      socket.assigns.rider_search.filters ++ if(new_filter, do: [new_filter], else: [])
 
     {:noreply,
      socket


### PR DESCRIPTION
Encode rider search filters into URL parameters and use push_patch for navigation, making filters bookmarkable and shareable. Replace in-memory filter updates with URL-driven state via push_filter_patch.

## Describe your changes

<!-- Please add a link to a ticket if relevant: eg: "closes #340" -->


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
