### PR TITLE
Paginated search

### DIFF
--- a/lib/bike_brigade_web/core_components.ex
+++ b/lib/bike_brigade_web/core_components.ex
@@ -458,6 +458,33 @@ defmodule BikeBrigadeWeb.CoreComponents do
     """
   end
 
+  attr :enabled, :boolean, required: true
+  attr :label, :string, default: nil
+  attr :rest, :global
+
+  def toggle(assigns) do
+    ~H"""
+    <div class="flex items-center gap-3">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={to_string(@enabled)}
+        class={[
+          "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2",
+          if(@enabled, do: "bg-indigo-600", else: "bg-gray-200")
+        ]}
+        {@rest}
+      >
+        <span class={[
+          "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+          if(@enabled, do: "translate-x-5", else: "translate-x-0")
+        ]} />
+      </button>
+      <span :if={@label} class="text-sm font-medium text-gray-900">{@label}</span>
+    </div>
+    """
+  end
+
   attr :id, :any
   attr :name, :any
   attr :label, :string, default: nil

--- a/lib/bike_brigade_web/live/user_live/index.ex
+++ b/lib/bike_brigade_web/live/user_live/index.ex
@@ -4,18 +4,25 @@ defmodule BikeBrigadeWeb.UserLive.Index do
   alias BikeBrigade.Accounts
   alias BikeBrigade.Accounts.User
 
+  @per_page 20
+
   @impl true
   def mount(_params, _session, socket) do
     if socket.assigns.current_user.is_dispatcher do
       {:ok,
        socket
        |> assign(:page, :users)
-       |> assign(:users, list_users())}
+       |> assign(:search, "")
+       |> assign(:dispatchers_only, true)
+       |> assign(:current_page, 1)
+       |> assign(:total, 0)
+       |> assign(:page_first, 0)
+       |> assign(:page_last, 0)
+       |> assign(:users, [])}
     else
       {:ok,
        socket
        |> put_flash(:error, "You must be a dispatcher to view this page")
-       # TODO redirect where?
        |> push_navigate(to: "/riders")}
     end
   end
@@ -37,21 +44,98 @@ defmodule BikeBrigadeWeb.UserLive.Index do
     |> assign(:user, %User{})
   end
 
-  defp apply_action(socket, :index, _params) do
+  defp apply_action(socket, :index, params) do
+    search = Map.get(params, "search", "")
+    dispatchers_only = Map.get(params, "dispatchers_only", "true") == "true"
+    page = params |> Map.get("page", "1") |> String.to_integer() |> max(1)
+
+    {users, total} =
+      Accounts.list_users_paginated(%{
+        search: search,
+        dispatchers_only: dispatchers_only,
+        page: page
+      })
+
+    page_first = if total == 0, do: 0, else: (page - 1) * @per_page + 1
+    page_last = min(page * @per_page, total)
+
     socket
     |> assign(:page_title, "Listing Users")
     |> assign(:user, nil)
+    |> assign(:users, users)
+    |> assign(:search, search)
+    |> assign(:dispatchers_only, dispatchers_only)
+    |> assign(:current_page, page)
+    |> assign(:total, total)
+    |> assign(:page_first, page_first)
+    |> assign(:page_last, page_last)
   end
 
   @impl true
+  def handle_event("search", %{"search" => search}, socket) do
+    {:noreply, push_patch(socket, to: patch_path(socket, search: search, page: 1))}
+  end
+
+  def handle_event("clear_search", _params, socket) do
+    {:noreply, push_patch(socket, to: patch_path(socket, search: "", page: 1))}
+  end
+
+  def handle_event("toggle_dispatchers", _params, socket) do
+    {:noreply,
+     push_patch(socket,
+       to: patch_path(socket, dispatchers_only: !socket.assigns.dispatchers_only, page: 1)
+     )}
+  end
+
+  def handle_event("next_page", _params, socket) do
+    {:noreply, push_patch(socket, to: patch_path(socket, page: socket.assigns.current_page + 1))}
+  end
+
+  def handle_event("prev_page", _params, socket) do
+    {:noreply,
+     push_patch(socket, to: patch_path(socket, page: max(socket.assigns.current_page - 1, 1)))}
+  end
+
   def handle_event("delete", %{"id" => id}, socket) do
     user = Accounts.get_user(id)
     {:ok, _} = Accounts.delete_user(user)
 
-    {:noreply, assign(socket, :users, list_users())}
+    {:noreply, fetch_users(socket)}
   end
 
-  defp list_users do
-    Accounts.list_users()
+  defp fetch_users(socket) do
+    page = socket.assigns.current_page
+
+    {users, total} =
+      Accounts.list_users_paginated(%{
+        search: socket.assigns.search,
+        dispatchers_only: socket.assigns.dispatchers_only,
+        page: page
+      })
+
+    page_first = if total == 0, do: 0, else: (page - 1) * @per_page + 1
+    page_last = min(page * @per_page, total)
+
+    socket
+    |> assign(:users, users)
+    |> assign(:total, total)
+    |> assign(:page_first, page_first)
+    |> assign(:page_last, page_last)
+  end
+
+  defp patch_path(socket, overrides) do
+    search = Keyword.get(overrides, :search, socket.assigns.search)
+    dispatchers_only = Keyword.get(overrides, :dispatchers_only, socket.assigns.dispatchers_only)
+    page = Keyword.get(overrides, :page, socket.assigns.current_page)
+
+    params =
+      %{}
+      |> then(fn p -> if search != "", do: Map.put(p, "search", search), else: p end)
+      |> then(fn p ->
+        if !dispatchers_only, do: Map.put(p, "dispatchers_only", "false"), else: p
+      end)
+      |> then(fn p -> if page > 1, do: Map.put(p, "page", page), else: p end)
+
+    ~p"/users?#{params}"
   end
 end

--- a/lib/bike_brigade_web/live/user_live/index.html.heex
+++ b/lib/bike_brigade_web/live/user_live/index.html.heex
@@ -4,6 +4,30 @@
     All of the users who have access to the Dispatch app. This includes Dispatchers and Riders.
   </:subtitle>
 </.header>
+
+<div class="flex items-center justify-between mt-4 mb-2 space-x-4">
+  <form phx-submit="search" class="flex-1 max-w-md">
+    <div class="relative">
+      <input
+        type="text"
+        name="search"
+        value={@search}
+        placeholder="Search by name..."
+        class="w-full px-3 py-2 pr-8 border border-gray-300 rounded-md shadow-sm sm:text-sm focus:ring-indigo-500 focus:border-indigo-500"
+      />
+      <button
+        :if={@search != ""}
+        type="button"
+        phx-click="clear_search"
+        class="absolute inset-y-0 right-0 flex items-center pr-2 text-gray-400 hover:text-gray-500"
+      >
+        <Heroicons.x_mark mini class="w-5 h-5" />
+      </button>
+    </div>
+  </form>
+  <.toggle enabled={@dispatchers_only} label="Dispatchers only" phx-click="toggle_dispatchers" />
+</div>
+
 <.table id="users" rows={@users} row_class="user-row">
   <:col :let={user} label="Name">
     <div class="flex items-center">
@@ -46,6 +70,34 @@
       Delete <span class="sr-only">, {user.name}</span>
     </.link>
   </:action>
+
+  <:footer>
+    <nav
+      class="flex items-center justify-between px-4 py-3 bg-white border-t border-gray-200 sm:px-6"
+      aria-label="Pagination"
+    >
+      <div class="hidden sm:block">
+        <p class="text-sm text-gray-700">
+          Showing <span class="font-medium">{@page_first}</span>
+          to <span class="font-medium">{@page_last}</span>
+          of <span class="font-medium">{@total}</span>
+          results
+        </p>
+      </div>
+      <div class="flex justify-between flex-1 sm:justify-end">
+        <%= if @page_first > 1 do %>
+          <.button phx-click="prev_page" color={:white}>
+            Previous
+          </.button>
+        <% end %>
+        <%= if @page_last < @total do %>
+          <.button phx-click="next_page" color={:white} class="ml-3">
+            Next
+          </.button>
+        <% end %>
+      </div>
+    </nav>
+  </:footer>
 </.table>
 
 <.modal


### PR DESCRIPTION
Add paginated and searchable users index with a "Dispatchers only" toggle (default on). Search filters by name, state persists in URL params, and pagination follows the riders page pattern. Also adds a reusable toggle component to core_components.

## Describe your changes

<!-- Please add a link to a ticket if relevant: eg: "closes #340" -->


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
