### PR TITLE
Optimize weekday filter with JOIN

### DIFF
--- a/lib/bike_brigade/riders/rider_search.ex
+++ b/lib/bike_brigade/riders/rider_search.ex
@@ -309,8 +309,7 @@ defmodule BikeBrigade.Riders.RiderSearch do
         f.type == :active and f.search in ["week", "month"]
       end)
 
-    # Build aggregated weekday stats subquery (executed once, not per-rider)
-    # This replaces the correlated EXISTS subquery for better performance
+    # Build aggregated weekday stats subquery
     weekday_stats_subquery =
       from(c in BikeBrigade.Delivery.Campaign,
         join: cr in "campaigns_riders",


### PR DESCRIPTION
# Optimize weekday filter performance in rider search

## Problem

The rider search functionality had a significant performance bottleneck when filtering riders by weekday availability (e.g., "find riders active on Mondays"). The implementation used a **correlated EXISTS subquery** that executed once per rider, causing O(n) performance degradation where n = number of riders.

## Solution

Replace the correlated EXISTS subquery with a **LEFT JOIN to a pre-aggregated subquery**. The aggregation now happens once for all riders, then the results are joined.

## Video

https://github.com/user-attachments/assets/1a191b5e-669b-44bf-a288-7a62cfbf26a9



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x ] If it is a core feature, I have added tests. -  Existing feature 
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above. - No
