### PR TITLE
Replace appearances of "The Island" as neighbourhood

### DIFF
--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -368,4 +368,16 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     |> Enum.map(&String.upcase/1)
     |> Enum.join()
   end
+
+  # This private fn handles an edgecase where certain addresses
+  # trigger a neighbourhood name called "Waterfront Communities / The Island"
+  # We don't want people to think they have to deliver to the island,
+  # so let's just do a simple string replacement.
+  defp render_neighbourhood_name(dropoff_location_str) do
+     neighbourhood = Locations.neighborhood(dropoff_location_str)
+     case neighbourhood do
+      "Waterfront Communities-The Island" -> "Waterfront Communities"
+      _ -> neighbourhood
+    end
+  end
 end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -374,8 +374,9 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
   # We don't want people to think they have to deliver to the island,
   # so let's just do a simple string replacement.
   defp render_neighbourhood_name(dropoff_location_str) do
-     neighbourhood = Locations.neighborhood(dropoff_location_str)
-     case neighbourhood do
+    neighbourhood = Locations.neighborhood(dropoff_location_str)
+
+    case neighbourhood do
       "Waterfront Communities-The Island" -> "Waterfront Communities"
       _ -> neighbourhood
     end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -377,7 +377,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     neighbourhood = Locations.neighborhood(dropoff_location_str)
 
     case neighbourhood do
-      "Waterfront Communities-The Island" -> "Waterfront Communities"
+      "Waterfront Communities-The Island" -> "St. Lawrence Market"
       _ -> neighbourhood
     end
   end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -20,7 +20,7 @@
     </:col>
     <:col :let={task} label="Recipient">{initials(task.dropoff_name)}</:col>
     <:col :let={task} label="Dropoff Neighbourhood">
-      {Locations.neighborhood(task.dropoff_location)}
+      {render_neighbourhood_name(task.dropoff_location)}
     </:col>
 
     <:col :let={task} label="Signup Notes">
@@ -54,7 +54,9 @@
 
       <div class="flex items-start px-4 py-2 space-x-2 border-b">
         <span class="font-semibold">Dropoff Neighbourhood:</span>
-        <span>{Locations.neighborhood(t.dropoff_location)}</span>
+        <span>
+          {render_neighbourhood_name(task.dropoff_location)}
+        </span>
       </div>
       <div :if={t.signup_notes} class="flex items-start px-4 py-2 space-x-2 border-b">
         <span class="font-semibold">Signup Notes</span>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.html.heex
@@ -55,7 +55,7 @@
       <div class="flex items-start px-4 py-2 space-x-2 border-b">
         <span class="font-semibold">Dropoff Neighbourhood:</span>
         <span>
-          {render_neighbourhood_name(task.dropoff_location)}
+          {render_neighbourhood_name(t.dropoff_location)}
         </span>
       </div>
       <div :if={t.signup_notes} class="flex items-start px-4 py-2 space-x-2 border-b">

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -255,7 +255,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
 
       displayed_neighbourhood =
         if raw_neighbourhood == "Waterfront Communities-The Island",
-          do: "Waterfront Communities",
+          do: "St. Lawrence Market",
           else: raw_neighbourhood
 
       assert html =~ displayed_neighbourhood

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -251,7 +251,15 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       refute html =~ ctx.task.dropoff_name
 
       assert live |> element("[data-test-id=dropoff-name-#{ctx.task.id}]") |> render =~ "CJH"
-      assert html =~ BikeBrigade.Locations.neighborhood(ctx.task.dropoff_location)
+      raw_neighbourhood = BikeBrigade.Locations.neighborhood(ctx.task.dropoff_location)
+
+      displayed_neighbourhood =
+        if raw_neighbourhood == "Waterfront Communities-The Island",
+          do: "Waterfront Communities",
+          else: raw_neighbourhood
+
+      assert html =~ displayed_neighbourhood
+      refute html =~ "Waterfront Communities-The Island"
 
       # We show the name and description of the item
       assert html =~ "Burrito"


### PR DESCRIPTION
I looked at the GeoJSON for the Waterfront Islands Community Polygon and it maps out to this part of Toronto.

<img width="735" height="710" alt="image" src="https://github.com/user-attachments/assets/2b5d58e0-e02e-42e6-96af-bd346c058ae5" />

so for now I think it does make sense as we discussed in slack to just show "St. Lawrence Market" for addresses within this polygon. 