### PR TITLE
Show non-dispatch users their capacity in their profile

### DIFF
--- a/lib/bike_brigade_web/live/rider_live/show.html.heex
+++ b/lib/bike_brigade_web/live/rider_live/show.html.heex
@@ -69,7 +69,6 @@
         </span>
       </p>
       <p
-        :if={@current_user.is_dispatcher}
         data-testid="dispatch-data-capacity"
         class="text-sm !leading-relaxed xl:text-base"
       >
@@ -79,14 +78,18 @@
             aria-label="Briefcase"
             class="inline-flex flex-shrink-0 w-5 h-5 text-gray-500 sm:mr-.5"
           />
-          <.link
-            navigate={~p"/riders?#{%{filters: ["capacity:#{@rider.capacity}"]}}"}
-            class="link"
-          >
+          <%= if @current_user.is_dispatcher do %>
+            <.link
+              navigate={~p"/riders?#{%{filters: ["capacity:#{@rider.capacity}"]}}"}
+              class="link"
+            >
+              {capacity_description(@rider.capacity)}
+            </.link>
+          <% else %>
             {capacity_description(@rider.capacity)}
-          </.link>
+          <% end %>
         </span>
-        <%= if @rider.text_based_itinerary do %>
+        <%= if @current_user.is_dispatcher && @rider.text_based_itinerary do %>
           <span class="">
             <Heroicons.signal_slash
               mini

--- a/test/bike_brigade_web/live/rider_live_test.exs
+++ b/test/bike_brigade_web/live/rider_live_test.exs
@@ -78,9 +78,9 @@ defmodule BikeBrigadeWeb.RiderLiveTest do
   describe "Show: rider logged-in" do
     setup [:create_rider, :login_as_rider]
 
-    test "Logged in rider cannot see their capacity", %{conn: conn} do
+    test "Logged in rider can see their capacity", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/profile")
-      refute html =~ "dispatch-data-capacity"
+      assert html =~ "dispatch-data-capacity"
     end
   end
 


### PR DESCRIPTION
## Describe your changes

<!-- Please add a link to a ticket if relevant: eg: "closes #340" -->


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Capacity information is now interactive for dispatchers; displays as plain text for other users
  * Text-based delivery instructions indicator now visible only to dispatchers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->