### PR TITLE
Add CampaignDeliverySummary module for aggregating delivery data

### DIFF
--- a/lib/bike_brigade/delivery/campaign_delivery_summary.ex
+++ b/lib/bike_brigade/delivery/campaign_delivery_summary.ex
@@ -1,0 +1,58 @@
+defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
+  defstruct total: 0, completed: 0, assigned: %{}, unassigned: []
+
+  @spec new() :: %BikeBrigade.Delivery.CampaignDeliverySummary{
+          assigned: %{},
+          completed: 1,
+          total: 0,
+          unassigned: []
+        }
+  def new(), do: %__MODULE__{}
+
+  def add_task(cds, task) do
+    cds
+    |> Map.update!(:total, &(&1 + 1))
+    |> completed(task)
+    |> delivery(task)
+  end
+
+  defimpl Collectable do
+    defp collect(cds, {:cont, task}), do: @for.add_task(cds, task)
+    defp collect(cds, :done), do: cds
+    defp collect(_cds, :halt), do: :ok
+    def into(tasks), do: {tasks, &collect/2}
+  end
+
+  defp completed(summary, %{delivery_status: :completed}),
+    do: Map.update!(summary, :completed, &(&1 + 1))
+
+  defp completed(%{completed: _completed} = summary, _task), do: summary
+
+  defp delivery(summary, %{assigned_rider_id: nil} = task) do
+    Map.update!(summary, :unassigned, &append(&1, task))
+  end
+
+  defp delivery(summary, task) do
+    Map.update!(summary, :assigned, &append_assigned(&1, task))
+  end
+
+  defp append_assigned(assigned, %{assigned_rider: %{name: name}} = task) do
+    assigned
+    |> Map.put_new(name, [])
+    |> Map.update!(name, &[delivery_summary(task) | &1])
+  end
+
+  defp append(acc, task), do: [delivery_summary(task) | acc]
+
+  defp delivery_summary(%{
+         dropoff_name: dropoff_name,
+         delivery_status: delivery_status,
+         task_items: task_items
+       }) do
+    %{
+      dropoff_name: dropoff_name,
+      delivery_status: delivery_status,
+      items: Enum.map_join(task_items, ", ", & &1.item.name)
+    }
+  end
+end

--- a/lib/bike_brigade/delivery/campaign_delivery_summary.ex
+++ b/lib/bike_brigade/delivery/campaign_delivery_summary.ex
@@ -1,13 +1,21 @@
 defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
-  defstruct total: 0, completed: 0, assigned: %{}, unassigned: []
+  defstruct name: nil,
+            delivery_start: nil,
+            delivery_end: nil,
+            total: 0,
+            completed: 0,
+            assigned: %{},
+            unassigned: []
 
-  @spec new() :: %BikeBrigade.Delivery.CampaignDeliverySummary{
-          assigned: %{},
-          completed: 1,
-          total: 0,
-          unassigned: []
-        }
   def new(), do: %__MODULE__{}
+
+  def new(campaign) do
+    %__MODULE__{
+      name: campaign.program.name,
+      delivery_start: campaign.delivery_start,
+      delivery_end: campaign.delivery_end
+    }
+  end
 
   def add_task(cds, task) do
     cds

--- a/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
+++ b/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
@@ -1,0 +1,84 @@
+defmodule BikeBrigade.Delivery.CampaignDeliverySummaryTest do
+  use BikeBrigade.DataCase
+
+  alias BikeBrigade.{Delivery, LocalizedDateTime}
+
+  alias BikeBrigade.Delivery.CampaignDeliverySummary, as: CDS
+
+  test "validate the initial structure" do
+    assert %CDS{completed: 0, total: 0, unassigned: [], assigned: %{}} == CDS.new()
+  end
+
+  describe "add_task/2" do
+    setup do
+      program = fixture(:program, %{name: "ACME Delivery"})
+
+      campaign =
+        fixture(:campaign, %{
+          program_id: program.id,
+          delivery_start: LocalizedDateTime.localize(~N[2023-01-01 10:00:00]),
+          delivery_end: LocalizedDateTime.localize(~N[2023-01-01 11:00:00])
+        })
+
+      rider = fixture(:rider, %{name: "Hannah Bannana"})
+      task = fixture(:task, %{campaign: campaign, rider: rider})
+      unassigned_task = fixture(:task, %{campaign: campaign})
+      preload_unassigned_task = Delivery.get_task(unassigned_task.id)
+      {:ok, completed_task} = Delivery.mark_task_complete_by_rider(task.id, rider.id)
+      %{completed_task: completed_task, unassigned_task: preload_unassigned_task}
+    end
+
+    test "validate single completed task count", %{completed_task: completed_task} do
+      cds = CDS.new()
+      original_completed = cds.completed
+      updated_cds = CDS.add_task(cds, completed_task)
+      assert updated_cds.completed == original_completed + 1
+    end
+
+    test "validate single task count", %{completed_task: completed_task} do
+      cds = CDS.new()
+      original_total = cds.total
+      updated_cds = CDS.add_task(cds, completed_task)
+      assert updated_cds.total == original_total + 1
+    end
+
+    test "validate empty unassigned task", %{completed_task: completed_task} do
+      cds = CDS.new()
+      original_unassigned = cds.unassigned
+      updated_cds = CDS.add_task(cds, completed_task)
+      assert updated_cds.unassigned == original_unassigned
+    end
+
+    test "validate assigned completed task contains rider name as key", %{
+      completed_task: completed_task
+    } do
+      rider_name = completed_task.assigned_rider.name
+      updated_cds = CDS.new() |> CDS.add_task(completed_task)
+      assert Map.has_key?(updated_cds.assigned, rider_name)
+    end
+
+    test "validate assigned completed task details", %{completed_task: completed_task} do
+      rider_name = completed_task.assigned_rider.name
+      task_item_names = Enum.map_join(completed_task.task_items, ", ", & &1.item.name)
+
+      updated_cds = CDS.new() |> CDS.add_task(completed_task)
+      [delivery_details] = Map.get(updated_cds.assigned, rider_name)
+      assert delivery_details.dropoff_name == completed_task.dropoff_name
+      assert delivery_details.items == task_item_names
+    end
+
+    test "validate unassigned task with single task", %{unassigned_task: unassigned_task} do
+      updated_cds = CDS.new() |> CDS.add_task(unassigned_task)
+      assert length(updated_cds.unassigned) == 1
+    end
+
+    test "validate items in unassigned single task", %{unassigned_task: unassigned_task} do
+      task_item_names = Enum.map_join(unassigned_task.task_items, ", ", & &1.item.name)
+
+      updated_cds = CDS.new() |> CDS.add_task(unassigned_task)
+      [delivery_details] = updated_cds.unassigned
+      assert delivery_details.dropoff_name == unassigned_task.dropoff_name
+      assert delivery_details.items == task_item_names
+    end
+  end
+end

--- a/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
+++ b/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
@@ -6,7 +6,15 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummaryTest do
   alias BikeBrigade.Delivery.CampaignDeliverySummary, as: CDS
 
   test "validate the initial structure" do
-    assert %CDS{completed: 0, total: 0, unassigned: [], assigned: %{}} == CDS.new()
+    assert %CDS{
+             name: nil,
+             delivery_start: nil,
+             delivery_end: nil,
+             completed: 0,
+             total: 0,
+             unassigned: [],
+             assigned: %{}
+           } == CDS.new()
   end
 
   describe "add_task/2" do


### PR DESCRIPTION
https://github.com/bikebrigade/dispatch/issues/476

## Describe your changes

This module provides a data structure to consolidate campaign delivery information into a summary format suitable for various use cases.
  * Track total and completed task counts
  * Group assigned deliveries by rider name
  * Collect unassigned deliveries separately
  * Implement Collectable protocol for use with Enum.into/2
  * Include delivery details: dropoff name, status, and item names

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
