### PR TITLE
Add list_campaigns_ended_between/2 to query campaigns by end time

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -312,6 +312,24 @@ defmodule BikeBrigade.Delivery do
   end
 
   @doc """
+  Returns campaigns whose delivery window ended within the given time range.
+
+  ## Parameters
+    - `from_datetime` - Start of the time window (inclusive)
+    - `to_datetime` - End of the time window (inclusive)
+  """
+  def list_campaigns_ended_between(from_utc_datetime, to_utc_datetime) do
+    query =
+      from c in Campaign,
+        where:
+          c.delivery_end >= ^from_utc_datetime and
+            c.delivery_end <= ^to_utc_datetime,
+        select: c
+
+    Repo.all(query)
+  end
+
+  @doc """
   Fetches how many open vs filled tasks there are (optionally, by week)
   and groups them by campaign ID.
   Written in order to show how "full" a campaign is.

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -345,5 +345,32 @@ defmodule BikeBrigade.DeliveryTest do
     end
   end
 
+  describe "list_campaigns_ended_between/2" do
+    setup do
+      campaign =
+        fixture(:campaign, %{
+          delivery_start: NaiveDateTime.utc_now() |> NaiveDateTime.add(-7, :hour),
+          delivery_end: NaiveDateTime.utc_now() |> NaiveDateTime.add(-1, :hour)
+        })
+
+      %{campaign: campaign}
+    end
+
+    test "returns a campaign available in the given window", %{campaign: campaign} do
+      from_datetime = NaiveDateTime.utc_now() |> NaiveDateTime.add(-75, :minute)
+      to_datetime = NaiveDateTime.utc_now() |> NaiveDateTime.add(-60, :minute)
+
+      [ended_campaign] = Delivery.list_campaigns_ended_between(from_datetime, to_datetime)
+      assert campaign.id == ended_campaign.id
+    end
+
+    test "returns no campaign in the given window" do
+      from_datetime = NaiveDateTime.utc_now() |> NaiveDateTime.add(-45, :minute)
+      to_datetime = NaiveDateTime.utc_now() |> NaiveDateTime.add(-30, :minute)
+
+      assert [] == Delivery.list_campaigns_ended_between(from_datetime, to_datetime)
+    end
+  end
+
   def item_name(%Task{task_items: [%{item: %{name: item_name}}]}), do: item_name
 end

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -347,30 +347,37 @@ defmodule BikeBrigade.DeliveryTest do
 
   describe "list_campaigns_ended_between/2" do
     setup do
+      now = get_utc_now()
+
       campaign =
         fixture(:campaign, %{
-          delivery_start: NaiveDateTime.utc_now() |> NaiveDateTime.add(-7, :hour),
-          delivery_end: NaiveDateTime.utc_now() |> NaiveDateTime.add(-1, :hour)
+          delivery_start: NaiveDateTime.add(now, -7, :hour),
+          delivery_end: NaiveDateTime.add(now, -1, :hour)
         })
 
-      %{campaign: campaign}
+      %{campaign: campaign, now: now}
     end
 
-    test "returns a campaign available in the given window", %{campaign: campaign} do
-      from_datetime = NaiveDateTime.utc_now() |> NaiveDateTime.add(-75, :minute)
-      to_datetime = NaiveDateTime.utc_now() |> NaiveDateTime.add(-60, :minute)
+    test "returns a campaign available in the given window", %{
+      campaign: campaign,
+      now: now
+    } do
+      from_datetime = NaiveDateTime.add(now, -75, :minute)
+      to_datetime = NaiveDateTime.add(now, -60, :minute)
 
       [ended_campaign] = Delivery.list_campaigns_ended_between(from_datetime, to_datetime)
       assert campaign.id == ended_campaign.id
     end
 
-    test "returns no campaign in the given window" do
-      from_datetime = NaiveDateTime.utc_now() |> NaiveDateTime.add(-45, :minute)
-      to_datetime = NaiveDateTime.utc_now() |> NaiveDateTime.add(-30, :minute)
+    test "returns no campaign in the given window", %{now: now} do
+      from_datetime = NaiveDateTime.add(now, -45, :minute)
+      to_datetime = NaiveDateTime.add(now, -30, :minute)
 
       assert [] == Delivery.list_campaigns_ended_between(from_datetime, to_datetime)
     end
   end
 
   def item_name(%Task{task_items: [%{item: %{name: item_name}}]}), do: item_name
+
+  defp get_utc_now(), do: NaiveDateTime.utc_now()
 end


### PR DESCRIPTION
https://github.com/bikebrigade/dispatch/issues/476

## Describe your changes

This function enables finding campaigns whose delivery window ended within a specified time range. It's designed to support a scheduled job that runs every 15 minutes to process recently ended campaigns.

The function:
- Accepts from_datetime and to_datetime as NaiveDateTime
- Uses inclusive bounds (>= and <=) for the time window
- Returns a list of Campaign structs without preloads

Test coverage includes:
- Finding campaigns within the specified window
- Returning empty list when no campaigns match

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
