### PR TITLE
Add SlackCampaignSummaryMessage schema to track posted summaries

### DIFF
--- a/lib/bike_brigade/messaging/slack_campaign_summary_message.ex
+++ b/lib/bike_brigade/messaging/slack_campaign_summary_message.ex
@@ -1,0 +1,25 @@
+defmodule BikeBrigade.Messaging.SlackCampaignSummaryMessage do
+  use BikeBrigade.Schema
+
+  alias BikeBrigade.Delivery.Campaign
+
+  import Ecto.Changeset
+
+  schema "slack_campaign_messages" do
+    field :slack_channel_id, :string
+    field :raw_message, :string
+    field :sent_at, :utc_datetime
+    belongs_to :campaign, Campaign
+
+    timestamps()
+  end
+
+  @required_params [:slack_channel_id, :raw_message, :campaign_id]
+  @available_params [:sent_at | @required_params]
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @available_params)
+    |> validate_required(@required_params)
+  end
+end

--- a/priv/repo/migrations/20260329221529_add_slack_campaign_summary_messages.exs
+++ b/priv/repo/migrations/20260329221529_add_slack_campaign_summary_messages.exs
@@ -1,0 +1,17 @@
+defmodule BikeBrigade.Repo.Migrations.AddSlackCampaignSummaryMessages do
+  use Ecto.Migration
+
+  def change do
+    create table(:slack_campaign_messages) do
+      add :slack_channel_id, :string, null: false
+      add :raw_message, :text, null: false
+      add :sent_at, :utc_datetime
+      add :campaign_id, references(:campaigns, on_delete: :nilify_all)
+
+      timestamps()
+    end
+
+    create index(:slack_campaign_messages, [:campaign_id])
+    create index(:slack_campaign_messages, [:sent_at])
+  end
+end

--- a/priv/repo/migrations/20260329221529_add_slack_campaign_summary_messages.exs
+++ b/priv/repo/migrations/20260329221529_add_slack_campaign_summary_messages.exs
@@ -11,7 +11,7 @@ defmodule BikeBrigade.Repo.Migrations.AddSlackCampaignSummaryMessages do
       timestamps()
     end
 
-    create index(:slack_campaign_messages, [:campaign_id])
+    create unique_index(:slack_campaign_messages, [:campaign_id])
     create index(:slack_campaign_messages, [:sent_at])
   end
 end

--- a/test/bike_brigade/riders/rider_search_test.exs
+++ b/test/bike_brigade/riders/rider_search_test.exs
@@ -123,7 +123,7 @@ defmodule BikeBrigade.Riders.RiderSearchTest do
   end
 
   defp create_campaign_for_date(date) do
-    datetime = DateTime.new!(date, ~T[12:00:00], "Etc/UTC")
+    datetime = DateTime.new!(date, ~T[00:00:00], "Etc/UTC")
     fixture(:campaign, %{delivery_start: datetime})
   end
 


### PR DESCRIPTION
  https://github.com/bikebrigade/dispatch/issues/476

  

## Describe your changes

Introduces a new schema and migration to store records of campaign summary messages posted to Slack. This enables tracking which campaigns have already had summaries sent.

  Schema fields:
  - slack_channel_id: Target Slack channel
  - raw_message: The formatted message content
  - sent_at: When the message was posted
  - campaign_id: Reference to the associated campaign

The migration includes indexes on campaign_id and sent_at for efficient lookups when checking if a summary was already posted or querying by time range.

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
