### PR TITLE
Vn/slack campaign summary payload

### DIFF
--- a/lib/bike_brigade/delivery/campaign_delivery_summary.ex
+++ b/lib/bike_brigade/delivery/campaign_delivery_summary.ex
@@ -1,5 +1,6 @@
 defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
   defstruct name: nil,
+            campaign_id: nil,
             delivery_start: nil,
             delivery_end: nil,
             total: 0,
@@ -12,6 +13,7 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
   def new(campaign) do
     %__MODULE__{
       name: campaign.program.name,
+      campaign_id: campaign.id,
       delivery_start: campaign.delivery_start,
       delivery_end: campaign.delivery_end
     }

--- a/lib/bike_brigade/delivery/campaign_delivery_summary.ex
+++ b/lib/bike_brigade/delivery/campaign_delivery_summary.ex
@@ -1,0 +1,58 @@
+defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
+  defstruct total: 0, completed: 0, assigned: %{}, unassigned: []
+
+  @spec new() :: %BikeBrigade.Delivery.CampaignDeliverySummary{
+          assigned: %{},
+          completed: 1,
+          total: 0,
+          unassigned: []
+        }
+  def new(), do: %__MODULE__{}
+
+  def add_task(cds, task) do
+    cds
+    |> Map.update!(:total, &(&1 + 1))
+    |> completed(task)
+    |> delivery(task)
+  end
+
+  defimpl Collectable do
+    defp collect(cds, {:cont, task}), do: @for.add_task(cds, task)
+    defp collect(cds, :done), do: cds
+    defp collect(_cds, :halt), do: :ok
+    def into(tasks), do: {tasks, &collect/2}
+  end
+
+  defp completed(summary, %{delivery_status: :completed}),
+    do: Map.update!(summary, :completed, &(&1 + 1))
+
+  defp completed(%{completed: _completed} = summary, _task), do: summary
+
+  defp delivery(summary, %{assigned_rider_id: nil} = task) do
+    Map.update!(summary, :unassigned, &append(&1, task))
+  end
+
+  defp delivery(summary, task) do
+    Map.update!(summary, :assigned, &append_assigned(&1, task))
+  end
+
+  defp append_assigned(assigned, %{assigned_rider: %{name: name}} = task) do
+    assigned
+    |> Map.put_new(name, [])
+    |> Map.update!(name, &[delivery_summary(task) | &1])
+  end
+
+  defp append(acc, task), do: [delivery_summary(task) | acc]
+
+  defp delivery_summary(%{
+         dropoff_name: dropoff_name,
+         delivery_status: delivery_status,
+         task_items: task_items
+       }) do
+    %{
+      dropoff_name: dropoff_name,
+      delivery_status: delivery_status,
+      items: Enum.map_join(task_items, ", ", & &1.item.name)
+    }
+  end
+end

--- a/lib/bike_brigade/delivery/campaign_delivery_summary.ex
+++ b/lib/bike_brigade/delivery/campaign_delivery_summary.ex
@@ -1,13 +1,21 @@
 defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
-  defstruct total: 0, completed: 0, assigned: %{}, unassigned: []
+  defstruct name: nil,
+            delivery_start: nil,
+            delivery_end: nil,
+            total: 0,
+            completed: 0,
+            assigned: %{},
+            unassigned: []
 
-  @spec new() :: %BikeBrigade.Delivery.CampaignDeliverySummary{
-          assigned: %{},
-          completed: 1,
-          total: 0,
-          unassigned: []
-        }
   def new(), do: %__MODULE__{}
+
+  def new(campaign) do
+    %__MODULE__{
+      name: campaign.program.name,
+      delivery_start: campaign.delivery_start,
+      delivery_end: campaign.delivery_end
+    }
+  end
 
   def add_task(cds, task) do
     cds

--- a/lib/bike_brigade/messaging/slack.ex
+++ b/lib/bike_brigade/messaging/slack.ex
@@ -1,4 +1,5 @@
 defmodule BikeBrigade.Messaging.Slack do
+  alias BikeBrigade.Delivery.CampaignDeliverySummary
   alias BikeBrigade.SlackApi
   alias BikeBrigade.Repo
   import BikeBrigade.Utils
@@ -59,6 +60,14 @@ defmodule BikeBrigade.Messaging.Slack do
         Repo.preload(delivery_note, [:rider, :resolved_by, task: [campaign: :program]])
 
       delivery_note.task.campaign.program.slack_channel_id || get_config(:channel_id)
+    end
+  end
+
+  defmodule CampaignDeliverySummary do
+    def send_summary(channel, cds) do
+      channel
+      |> SlackApi.PayloadBuilder.build_delivery_summary(cds)
+      |> SlackApi.post_message!()
     end
   end
 end

--- a/lib/bike_brigade/slack_api/payload_builder.ex
+++ b/lib/bike_brigade/slack_api/payload_builder.ex
@@ -1,6 +1,12 @@
 defmodule BikeBrigade.SlackApi.PayloadBuilder do
   alias BikeBrigade.Messaging.SmsMessage
+  alias BikeBrigade.LocalizedDateTime
+
   use Phoenix.VerifiedRoutes, endpoint: BikeBrigadeWeb.Endpoint, router: BikeBrigadeWeb.Router
+
+  @full_date_format "%A %B %-d, %Y"
+  @time_format "%-I:%M %p"
+  @short_date_time_format "%a %b %-d, %-I:%M %p"
 
   def build(channel_id, %SmsMessage{rider: rider} = message) do
     text =
@@ -52,6 +58,98 @@ defmodule BikeBrigade.SlackApi.PayloadBuilder do
     }
     |> Jason.encode!()
   end
+
+  def build_delivery_summary(channel_id, cds) do
+    date_line = format_campaign_date_range(cds)
+
+    header = ":bar_chart: #{cds.name} Summary #{url(~p"/campaigns/#{cds.campaign_id}")}"
+
+    summary =
+      "#{date_line}\n\nDeliveries: #{cds.total}\nCompleted: #{cds.completed}"
+
+    rider_blocks =
+      cds.assigned
+      |> Map.to_list()
+      |> Enum.sort_by(fn {name, _tasks} -> name end)
+      |> Enum.map(&build_rider_block/1)
+
+    unassigned_blocks = build_unassigned_block(cds.unassigned)
+
+    blocks =
+      [
+        %{type: "section", text: %{type: "mrkdwn", text: header}},
+        %{type: "section", text: %{type: "mrkdwn", text: summary}},
+        %{type: "divider"}
+      ] ++ rider_blocks ++ unassigned_blocks
+
+    %{channel: channel_id, blocks: blocks}
+    |> Jason.encode!()
+  end
+
+  defp format_campaign_date_range(%{delivery_start: start, delivery_end: end_dt}) do
+    dates = {LocalizedDateTime.to_date(start), LocalizedDateTime.to_date(end_dt)}
+
+    case dates do
+      {date, date} ->
+        date = format_localized(start, @full_date_format)
+        start_time = format_localized(start, @time_format)
+        end_time = format_localized(end_dt, @time_format)
+
+        "#{date} #{start_time} - #{end_time}"
+
+      {_start_date, _end_date} ->
+        "#{format_localized(start, @short_date_time_format)} - #{format_localized(end_dt, @short_date_time_format)}"
+    end
+  end
+
+  defp format_localized(datetime, format) do
+    datetime
+    |> LocalizedDateTime.localize()
+    |> Calendar.strftime(format)
+  end
+
+  defp build_rider_block({rider_name, tasks}) do
+    total = length(tasks)
+    completed = Enum.count(tasks, &(&1.delivery_status == :completed))
+    status_text = "(#{completed}/#{total})"
+    task_lines = format_task_lines(tasks)
+
+    %{
+      type: "section",
+      text: %{
+        type: "mrkdwn",
+        text: ":bicyclist: *#{filter_mrkdwn(rider_name)}* #{status_text}\n#{task_lines}"
+      }
+    }
+  end
+
+  defp build_unassigned_block([]), do: []
+
+  defp build_unassigned_block(unassigned_tasks) do
+    task_lines = format_task_lines(unassigned_tasks)
+
+    [
+      %{type: "divider"},
+      %{
+        type: "section",
+        text: %{type: "mrkdwn", text: ":package: *Unassigned Deliveries*\n#{task_lines}"}
+      }
+    ]
+  end
+
+  defp format_task_lines(tasks) do
+    tasks
+    |> Enum.reverse()
+    |> Enum.map_join("\n", &format_task_line/1)
+  end
+
+  defp format_task_line(task_data) do
+    status_icon = delivery_status_icon(task_data.delivery_status)
+    "#{filter_mrkdwn(task_data.dropoff_name)} - #{task_data.items} #{status_icon}"
+  end
+
+  defp delivery_status_icon(:completed), do: ":white_check_mark:"
+  defp delivery_status_icon(_), do: ":x:"
 
   def filter_mrkdwn(nil) do
     ""

--- a/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
+++ b/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
@@ -1,0 +1,84 @@
+defmodule BikeBrigade.Delivery.CampaignDeliverySummaryTest do
+  use BikeBrigade.DataCase
+
+  alias BikeBrigade.{Delivery, LocalizedDateTime}
+
+  alias BikeBrigade.Delivery.CampaignDeliverySummary, as: CDS
+
+  test "validate the initial structure" do
+    assert %CDS{completed: 0, total: 0, unassigned: [], assigned: %{}} == CDS.new()
+  end
+
+  describe "add_task/2" do
+    setup do
+      program = fixture(:program, %{name: "ACME Delivery"})
+
+      campaign =
+        fixture(:campaign, %{
+          program_id: program.id,
+          delivery_start: LocalizedDateTime.localize(~N[2023-01-01 10:00:00]),
+          delivery_end: LocalizedDateTime.localize(~N[2023-01-01 11:00:00])
+        })
+
+      rider = fixture(:rider, %{name: "Hannah Bannana"})
+      task = fixture(:task, %{campaign: campaign, rider: rider})
+      unassigned_task = fixture(:task, %{campaign: campaign})
+      preload_unassigned_task = Delivery.get_task(unassigned_task.id)
+      {:ok, completed_task} = Delivery.mark_task_complete_by_rider(task.id, rider.id)
+      %{completed_task: completed_task, unassigned_task: preload_unassigned_task}
+    end
+
+    test "validate single completed task count", %{completed_task: completed_task} do
+      cds = CDS.new()
+      original_completed = cds.completed
+      updated_cds = CDS.add_task(cds, completed_task)
+      assert updated_cds.completed == original_completed + 1
+    end
+
+    test "validate single task count", %{completed_task: completed_task} do
+      cds = CDS.new()
+      original_total = cds.total
+      updated_cds = CDS.add_task(cds, completed_task)
+      assert updated_cds.total == original_total + 1
+    end
+
+    test "validate empty unassigned task", %{completed_task: completed_task} do
+      cds = CDS.new()
+      original_unassigned = cds.unassigned
+      updated_cds = CDS.add_task(cds, completed_task)
+      assert updated_cds.unassigned == original_unassigned
+    end
+
+    test "validate assigned completed task contains rider name as key", %{
+      completed_task: completed_task
+    } do
+      rider_name = completed_task.assigned_rider.name
+      updated_cds = CDS.new() |> CDS.add_task(completed_task)
+      assert Map.has_key?(updated_cds.assigned, rider_name)
+    end
+
+    test "validate assigned completed task details", %{completed_task: completed_task} do
+      rider_name = completed_task.assigned_rider.name
+      task_item_names = Enum.map_join(completed_task.task_items, ", ", & &1.item.name)
+
+      updated_cds = CDS.new() |> CDS.add_task(completed_task)
+      [delivery_details] = Map.get(updated_cds.assigned, rider_name)
+      assert delivery_details.dropoff_name == completed_task.dropoff_name
+      assert delivery_details.items == task_item_names
+    end
+
+    test "validate unassigned task with single task", %{unassigned_task: unassigned_task} do
+      updated_cds = CDS.new() |> CDS.add_task(unassigned_task)
+      assert length(updated_cds.unassigned) == 1
+    end
+
+    test "validate items in unassigned single task", %{unassigned_task: unassigned_task} do
+      task_item_names = Enum.map_join(unassigned_task.task_items, ", ", & &1.item.name)
+
+      updated_cds = CDS.new() |> CDS.add_task(unassigned_task)
+      [delivery_details] = updated_cds.unassigned
+      assert delivery_details.dropoff_name == unassigned_task.dropoff_name
+      assert delivery_details.items == task_item_names
+    end
+  end
+end

--- a/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
+++ b/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
@@ -6,7 +6,15 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummaryTest do
   alias BikeBrigade.Delivery.CampaignDeliverySummary, as: CDS
 
   test "validate the initial structure" do
-    assert %CDS{completed: 0, total: 0, unassigned: [], assigned: %{}} == CDS.new()
+    assert %CDS{
+             name: nil,
+             delivery_start: nil,
+             delivery_end: nil,
+             completed: 0,
+             total: 0,
+             unassigned: [],
+             assigned: %{}
+           } == CDS.new()
   end
 
   describe "add_task/2" do

--- a/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
+++ b/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
@@ -8,6 +8,7 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummaryTest do
   test "validate the initial structure" do
     assert %CDS{
              name: nil,
+             campaign_id: nil,
              delivery_start: nil,
              delivery_end: nil,
              completed: 0,

--- a/test/bike_brigade/slack_api/payload_builder_test.exs
+++ b/test/bike_brigade/slack_api/payload_builder_test.exs
@@ -1,6 +1,8 @@
 defmodule BikeBrigade.SlackApi.PayloadBuilderTest do
   use BikeBrigade.DataCase, async: true
 
+  alias BikeBrigade.Delivery
+  alias BikeBrigade.Delivery.CampaignDeliverySummary
   alias BikeBrigade.SlackApi.PayloadBuilder
 
   use Phoenix.VerifiedRoutes, endpoint: BikeBrigadeWeb.Endpoint, router: BikeBrigadeWeb.Router
@@ -80,5 +82,141 @@ defmodule BikeBrigade.SlackApi.PayloadBuilderTest do
   defp create_sms(attrs, rider \\ fixture(:rider)) do
     defaults = %{rider_id: rider.id}
     fixture(:sms_message, Map.merge(defaults, attrs))
+  end
+
+  describe "build_delivery_summary" do
+    setup do
+      campaign = fixture(:campaign)
+      %{campaign: campaign}
+    end
+
+    test "header block contains program name and campaign URL", %{campaign: campaign} do
+      payload = build_delivery_summary_payload(campaign)
+      %{"blocks" => [%{"text" => %{"text" => header_text}} | _]} = Jason.decode!(payload)
+
+      assert header_text =~ campaign.program.name
+      assert header_text =~ url(~p"/campaigns/#{campaign.id}")
+    end
+
+    test "summary block shows total and completed delivery counts", %{campaign: campaign} do
+      rider = fixture(:rider)
+      fixture(:task, %{campaign: campaign, rider: rider, delivery_status: :completed})
+      fixture(:task, %{campaign: campaign, rider: rider})
+
+      payload = build_delivery_summary_payload(campaign)
+      %{"blocks" => [_, %{"text" => %{"text" => summary_text}} | _]} = Jason.decode!(payload)
+
+      assert summary_text =~ "Deliveries: 2"
+      assert summary_text =~ "Completed: 1"
+    end
+
+    test "unassigned tasks appear in a separate block", %{campaign: campaign} do
+      fixture(:task, %{campaign: campaign})
+
+      payload = build_delivery_summary_payload(campaign)
+      %{"blocks" => blocks} = Jason.decode!(payload)
+
+      unassigned =
+        Enum.find(blocks, fn b ->
+          b["type"] == "section" and String.contains?(b["text"]["text"], "Unassigned Deliveries")
+        end)
+
+      assert unassigned != nil
+    end
+
+    test "no unassigned block when all tasks have assigned riders", %{campaign: campaign} do
+      rider = fixture(:rider)
+      fixture(:task, %{campaign: campaign, rider: rider})
+
+      payload = build_delivery_summary_payload(campaign)
+      %{"blocks" => blocks} = Jason.decode!(payload)
+
+      refute Enum.any?(blocks, fn b ->
+               b["type"] == "section" and
+                 String.contains?(b["text"]["text"], "Unassigned Deliveries")
+             end)
+    end
+
+    test "rider blocks are sorted alphabetically by name", %{campaign: campaign} do
+      r1 = fixture(:rider, %{name: "Zara"})
+      r2 = fixture(:rider, %{name: "Alice"})
+      fixture(:task, %{campaign: campaign, rider: r1})
+      fixture(:task, %{campaign: campaign, rider: r2})
+
+      payload = build_delivery_summary_payload(campaign)
+      %{"blocks" => blocks} = Jason.decode!(payload)
+
+      rider_texts =
+        blocks
+        |> Enum.filter(fn b ->
+          b["type"] == "section" and String.contains?(b["text"]["text"], ":bicyclist:")
+        end)
+        |> Enum.map(& &1["text"]["text"])
+
+      assert [first | _] = rider_texts
+      assert first =~ "Alice"
+      assert List.last(rider_texts) =~ "Zara"
+    end
+
+    test "rider block shows completed/total task count", %{campaign: campaign} do
+      rider = fixture(:rider)
+      fixture(:task, %{campaign: campaign, rider: rider, delivery_status: :completed})
+      fixture(:task, %{campaign: campaign, rider: rider})
+
+      payload = build_delivery_summary_payload(campaign)
+      %{"blocks" => blocks} = Jason.decode!(payload)
+
+      rider_block =
+        Enum.find(blocks, fn b ->
+          b["type"] == "section" and String.contains?(b["text"]["text"], ":bicyclist:")
+        end)
+
+      assert rider_block["text"]["text"] =~ "(1/2)"
+    end
+
+    test "same-day campaign shows full date with time range" do
+      campaign =
+        fixture(:campaign, %{
+          delivery_start: ~U[2026-03-16 14:00:00Z],
+          delivery_end: ~U[2026-03-16 18:00:00Z]
+        })
+
+      payload = build_delivery_summary_payload(campaign)
+      %{"blocks" => [_, %{"text" => %{"text" => summary_text}} | _]} = Jason.decode!(payload)
+
+      # UTC 14:00 = 10:00 AM EDT, UTC 18:00 = 2:00 PM EDT (America/Toronto)
+      assert summary_text =~ "Monday March 16, 2026"
+      assert summary_text =~ "10:00 AM - 2:00 PM"
+    end
+
+    test "multi-day campaign shows short datetime range" do
+      campaign =
+        fixture(:campaign, %{
+          delivery_start: ~U[2026-03-16 14:00:00Z],
+          delivery_end: ~U[2026-03-17 18:00:00Z]
+        })
+
+      payload = build_delivery_summary_payload(campaign)
+      %{"blocks" => [_, %{"text" => %{"text" => summary_text}} | _]} = Jason.decode!(payload)
+
+      assert summary_text =~ "Mon Mar 16"
+      assert summary_text =~ "Tue Mar 17"
+    end
+
+    test "special characters in names are mrkdwn-escaped", %{campaign: campaign} do
+      rider = fixture(:rider, %{name: "Alice & Bob"})
+      fixture(:task, %{campaign: campaign, rider: rider, dropoff_name: "Name <With> Specials"})
+
+      payload = build_delivery_summary_payload(campaign)
+
+      assert payload =~ "Alice &amp; Bob"
+      assert payload =~ "Name &lt;With&gt; Specials"
+    end
+  end
+
+  defp build_delivery_summary_payload(campaign, channel_id \\ "C123") do
+    {_riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
+    cds = Enum.into(tasks, CampaignDeliverySummary.new(campaign))
+    PayloadBuilder.build_delivery_summary(channel_id, cds)
   end
 end


### PR DESCRIPTION
## Describe your changes

Formats CampaignDeliverySummary data into Slack messages using Block Kit for campaign completion updates.

Changes:

- Add build_delivery_summary/2 to PayloadBuilder for Slack Block Kit formatting
- Add campaign_id field to CampaignDeliverySummary struct
- Introduce Slack.CampaignDeliverySummary module with send_summary/2

Message format includes:

- Header with program name and campaign link
- Date/time range (same-day vs multi-day formatting)
- Total and completed delivery counts
- Rider sections with task lists and completion status
- Unassigned deliveries section (when applicable)


## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
