### PR TITLE
Use cyclist emoji instead of red cross for pending deliveries

### DIFF
--- a/lib/bike_brigade/slack_api/payload_builder.ex
+++ b/lib/bike_brigade/slack_api/payload_builder.ex
@@ -179,7 +179,7 @@ defmodule BikeBrigade.SlackApi.PayloadBuilder do
   end
 
   defp delivery_status_icon(:completed), do: ":white_check_mark:"
-  defp delivery_status_icon(_), do: ":x:"
+  defp delivery_status_icon(_), do: ":bicyclist:"
 
   def filter_mrkdwn(nil) do
     ""


### PR DESCRIPTION
## Describe your changes

Use cyclist emoji instead of red cross for pending deliveries

### Summary

Replace the red cross with a cyclist emoji for pending deliveries in Slack campaign summaries.

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slack messages now show :bicyclist: for non-completed deliveries instead of :x:. This clarifies that pending or in-progress deliveries are active, not failed.

<sup>Written for commit 716da9fb11d3024e7d551cb5207dab5451321042. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery status indicators in Slack notifications by updating the display for non-completed deliveries to show a bicycle emoji instead of an error icon, enhancing visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->