### PR TITLE
Remove unassigned deliveries section from campaign delivery summary

### DIFF
--- a/lib/bike_brigade/delivery/campaign_delivery_summary.ex
+++ b/lib/bike_brigade/delivery/campaign_delivery_summary.ex
@@ -3,8 +3,7 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
   A struct that aggregates delivery task statistics for a campaign.
 
   Used to generate summaries for Slack notifications after campaigns end.
-  Tracks total tasks, completed tasks, and groups deliveries by assigned rider
-  or as unassigned.
+  Tracks total assigned tasks, completed tasks, and groups deliveries by assigned rider.
 
   Implements the `Collectable` protocol, allowing tasks to be collected into
   a summary using `Enum.into/2`:
@@ -17,10 +16,9 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
     * `:campaign_id` - The campaign ID
     * `:delivery_start` - Campaign delivery start time
     * `:delivery_end` - Campaign delivery end time
-    * `:total` - Total number of tasks
+    * `:total` - Total number of assigned tasks
     * `:completed` - Number of completed tasks
     * `:assigned` - Map of rider names to their assigned delivery summaries
-    * `:unassigned` - List of unassigned delivery summaries
   """
 
   alias BikeBrigade.Delivery
@@ -31,8 +29,7 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
             delivery_end: nil,
             total: 0,
             completed: 0,
-            assigned: %{},
-            unassigned: []
+            assigned: %{}
 
   @doc "Creates an empty campaign delivery summary."
   def new(), do: %__MODULE__{}
@@ -50,7 +47,7 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
   @doc "Adds a task to the summary, updating totals and assignment tracking."
   def add_task(cds, task) do
     cds
-    |> Map.update!(:total, &(&1 + 1))
+    |> total_assigned_task(task)
     |> completed(task)
     |> delivery(task)
   end
@@ -67,14 +64,15 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
     def into(tasks), do: {tasks, &collect/2}
   end
 
+  defp total_assigned_task(summary, %{assigned_rider_id: nil} = _task), do: summary
+  defp total_assigned_task(summary, _task), do: Map.update!(summary, :total, &(&1 + 1))
+
   defp completed(summary, %{delivery_status: :completed}),
     do: Map.update!(summary, :completed, &(&1 + 1))
 
   defp completed(%__MODULE__{completed: _completed} = summary, _task), do: summary
 
-  defp delivery(summary, %{assigned_rider_id: nil} = task) do
-    Map.update!(summary, :unassigned, &append(&1, task))
-  end
+  defp delivery(summary, %{assigned_rider_id: nil} = _task), do: summary
 
   defp delivery(summary, task) do
     Map.update!(summary, :assigned, &append_assigned(&1, task))
@@ -85,8 +83,6 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummary do
     |> Map.put_new(name, [])
     |> Map.update!(name, &[delivery_summary(task) | &1])
   end
-
-  defp append(acc, task), do: [delivery_summary(task) | acc]
 
   defp delivery_summary(%{
          dropoff_name: dropoff_name,

--- a/lib/bike_brigade/slack_api/payload_builder.ex
+++ b/lib/bike_brigade/slack_api/payload_builder.ex
@@ -107,14 +107,12 @@ defmodule BikeBrigade.SlackApi.PayloadBuilder do
       |> Enum.sort_by(fn {name, _tasks} -> name end)
       |> Enum.map(&build_rider_block/1)
 
-    unassigned_blocks = build_unassigned_block(cds.unassigned)
-
     blocks =
       [
         %{type: "section", text: %{type: "mrkdwn", text: header}},
         %{type: "section", text: %{type: "mrkdwn", text: summary}},
         %{type: "divider"}
-      ] ++ rider_blocks ++ unassigned_blocks
+      ] ++ rider_blocks
 
     %{channel: channel_id, blocks: blocks}
     |> Jason.encode!()
@@ -151,20 +149,6 @@ defmodule BikeBrigade.SlackApi.PayloadBuilder do
         text: ":bicyclist: *#{filter_mrkdwn(rider_name)}* \n#{task_lines}"
       }
     }
-  end
-
-  defp build_unassigned_block([]), do: []
-
-  defp build_unassigned_block(unassigned_tasks) do
-    task_lines = format_task_lines(unassigned_tasks)
-
-    [
-      %{type: "divider"},
-      %{
-        type: "section",
-        text: %{type: "mrkdwn", text: ":package: *Unassigned Deliveries*\n#{task_lines}"}
-      }
-    ]
   end
 
   defp format_task_lines(tasks) do

--- a/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
+++ b/test/bike_brigade/delivery/campaign_delivery_summary_test.exs
@@ -13,7 +13,6 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummaryTest do
              delivery_end: nil,
              completed: 0,
              total: 0,
-             unassigned: [],
              assigned: %{}
            } == CDS.new()
   end
@@ -51,13 +50,6 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummaryTest do
       assert updated_cds.total == original_total + 1
     end
 
-    test "validate empty unassigned task", %{completed_task: completed_task} do
-      cds = CDS.new()
-      original_unassigned = cds.unassigned
-      updated_cds = CDS.add_task(cds, completed_task)
-      assert updated_cds.unassigned == original_unassigned
-    end
-
     test "validate assigned completed task contains rider name as key", %{
       completed_task: completed_task
     } do
@@ -76,18 +68,9 @@ defmodule BikeBrigade.Delivery.CampaignDeliverySummaryTest do
       assert delivery_details.items == task_item_names
     end
 
-    test "validate unassigned task with single task", %{unassigned_task: unassigned_task} do
+    test "excludes unassigned tasks from the total count", %{unassigned_task: unassigned_task} do
       updated_cds = CDS.new() |> CDS.add_task(unassigned_task)
-      assert length(updated_cds.unassigned) == 1
-    end
-
-    test "validate items in unassigned single task", %{unassigned_task: unassigned_task} do
-      task_item_names = Enum.map_join(unassigned_task.task_items, ", ", & &1.item.name)
-
-      updated_cds = CDS.new() |> CDS.add_task(unassigned_task)
-      [delivery_details] = updated_cds.unassigned
-      assert delivery_details.dropoff_name == unassigned_task.dropoff_name
-      assert delivery_details.items == task_item_names
+      assert updated_cds.total == 0
     end
   end
 end

--- a/test/bike_brigade/slack_api/payload_builder_test.exs
+++ b/test/bike_brigade/slack_api/payload_builder_test.exs
@@ -110,33 +110,6 @@ defmodule BikeBrigade.SlackApi.PayloadBuilderTest do
       assert summary_text =~ "Completed: 1"
     end
 
-    test "unassigned tasks appear in a separate block", %{campaign: campaign} do
-      fixture(:task, %{campaign: campaign})
-
-      payload = build_delivery_summary_payload(campaign)
-      %{"blocks" => blocks} = Jason.decode!(payload)
-
-      unassigned =
-        Enum.find(blocks, fn b ->
-          b["type"] == "section" and String.contains?(b["text"]["text"], "Unassigned Deliveries")
-        end)
-
-      assert unassigned != nil
-    end
-
-    test "no unassigned block when all tasks have assigned riders", %{campaign: campaign} do
-      rider = fixture(:rider)
-      fixture(:task, %{campaign: campaign, rider: rider})
-
-      payload = build_delivery_summary_payload(campaign)
-      %{"blocks" => blocks} = Jason.decode!(payload)
-
-      refute Enum.any?(blocks, fn b ->
-               b["type"] == "section" and
-                 String.contains?(b["text"]["text"], "Unassigned Deliveries")
-             end)
-    end
-
     test "rider blocks are sorted alphabetically by name", %{campaign: campaign} do
       r1 = fixture(:rider, %{name: "Zara"})
       r2 = fixture(:rider, %{name: "Alice"})


### PR DESCRIPTION
## Describe your changes

**Data Model (CampaignDeliverySummary)**

- Removed unassigned field from the struct
- Updated module documentation to remove references to unassigned tracking
- Clarified that :total now represents only assigned tasks

**Delivery Summary Logic**

- Modified add_task/2 to skip counting unassigned tasks in the total
- Introduced total_assigned_task/2 helper that only increments total for tasks with an assigned rider
- Removed delivery/2 clause that collected unassigned tasks
- Removed append/2 helper function (no longer needed)

**Slack Integration**

- Removed build_unassigned_block/1 function from PayloadBuilder
- Removed unassigned deliveries block from detailed delivery summary messages
- Simplified message building to only include rider-assigned deliveries

**Tests**

- Removed test validating empty unassigned list after adding a task
- Removed tests for unassigned task tracking and display
- Kept test validating unassigned tasks don't increment total count (renamed and clarified purpose)
- Removed debug IO.inspect statement from test

## Impact
Users will no longer see a separate "Unassigned Deliveries" section in campaign delivery summary Slack messages. The total delivery count reflects only assigned tasks, making the summary cleaner and more focused on actual rider assignments.
AI can make mistakes, so double-check responses

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Unassigned Deliveries" section from Slack campaign delivery summaries and stopped counting unassigned tasks in totals. The total now reflects only rider-assigned deliveries for a cleaner summary.

- **Refactors**
  - Dropped `unassigned` from `BikeBrigade.Delivery.CampaignDeliverySummary` and updated docs.
  - Added `total_assigned_task/2`; `add_task/2` only increments `total` for assigned tasks.
  - Simplified `delivery/2` to ignore unassigned tasks; removed `append/2` and the unassigned block in `PayloadBuilder`.
  - Removed tests for unassigned tracking/Slack block; kept a test to ensure unassigned tasks don't affect totals.

<sup>Written for commit 1bd488a5e923628c6076968ec93a7e1d8edd9de6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Delivery summaries now track only assigned deliveries; total counts reflect assigned tasks only.
  * Unassigned deliveries are no longer tracked or displayed separately in summaries.
  * Slack notifications no longer include an "Unassigned Deliveries" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->