### PR TITLE
Make delivery summary posting optional per program

### DIFF
--- a/lib/bike_brigade/campaign_summary_poster.ex
+++ b/lib/bike_brigade/campaign_summary_poster.ex
@@ -66,15 +66,7 @@ defmodule BikeBrigade.CampaignSummaryPoster do
     )
   end
 
-  defp do_post_summary(campaign, _, enabled) when enabled != true do
-    Logger.info("Skipping campaign #{campaign.id}: delivery summaries not enabled for program")
-  end
-
-  defp do_post_summary(campaign, nil, _) do
-    Logger.info("Skipping campaign #{campaign.id}: no Slack channel configured for program")
-  end
-
-  defp do_post_summary(campaign, channel_id, true) do
+  defp do_post_summary(campaign, channel_id, true) when is_binary(channel_id) do
     summary = CampaignDeliverySummary.create_for(campaign)
 
     with {:ok, record} <- find_or_create_record(campaign.id, channel_id, summary),
@@ -89,6 +81,14 @@ defmodule BikeBrigade.CampaignSummaryPoster do
       {:error, _reason} ->
         Slack.Operations.notify_campaign_error(campaign, "Failed to send summary")
     end
+  end
+
+  defp do_post_summary(campaign, _, false) do
+    Logger.info("Skipping campaign #{campaign.id}: delivery summaries not enabled for program")
+  end
+
+  defp do_post_summary(campaign, nil, _) do
+    Logger.info("Skipping campaign #{campaign.id}: no Slack channel configured for program")
   end
 
   defp find_or_create_record(campaign_id, channel_id, summary) do

--- a/lib/bike_brigade/campaign_summary_poster.ex
+++ b/lib/bike_brigade/campaign_summary_poster.ex
@@ -58,15 +58,23 @@ defmodule BikeBrigade.CampaignSummaryPoster do
   """
   def post_summary_for_campaign(campaign) do
     campaign = Repo.preload(campaign, :program)
-    do_post_summary(campaign, campaign.program.slack_channel_id)
+
+    do_post_summary(
+      campaign,
+      campaign.program.slack_channel_id,
+      campaign.program.send_delivery_summaries
+    )
   end
 
-  defp do_post_summary(campaign, nil) do
-    Logger.warning("Skipping campaign #{campaign.id}: no Slack channel configured for program")
-    Slack.Operations.notify_campaign_error(campaign, "No Slack channel configured")
+  defp do_post_summary(campaign, _, false) do
+    Logger.info("Skipping campaign #{campaign.id}: delivery summaries not enabled for program")
   end
 
-  defp do_post_summary(campaign, channel_id) do
+  defp do_post_summary(campaign, nil, _) do
+    Logger.info("Skipping campaign #{campaign.id}: no Slack channel configured for program")
+  end
+
+  defp do_post_summary(campaign, channel_id, true) do
     summary = CampaignDeliverySummary.create_for(campaign)
 
     with {:ok, record} <- find_or_create_record(campaign.id, channel_id, summary),

--- a/lib/bike_brigade/campaign_summary_poster.ex
+++ b/lib/bike_brigade/campaign_summary_poster.ex
@@ -66,7 +66,7 @@ defmodule BikeBrigade.CampaignSummaryPoster do
     )
   end
 
-  defp do_post_summary(campaign, _, false) do
+  defp do_post_summary(campaign, _, enabled) when enabled != true do
     Logger.info("Skipping campaign #{campaign.id}: delivery summaries not enabled for program")
   end
 

--- a/lib/bike_brigade/delivery/program.ex
+++ b/lib/bike_brigade/delivery/program.ex
@@ -43,6 +43,7 @@ defmodule BikeBrigade.Delivery.Program do
     field :public, :boolean, default: false
     field :hide_pickup_address, :boolean, default: false
     field :slack_channel_id, :string
+    field :send_delivery_summaries, :boolean, default: false
 
     # TODO: this is me trying out virtual fields again
     field :campaign_count, :integer, virtual: true
@@ -80,7 +81,8 @@ defmodule BikeBrigade.Delivery.Program do
       :spreadsheet_layout,
       :start_date,
       :photo_description,
-      :photos
+      :photos,
+      :send_delivery_summaries
     ])
     |> validate_required([:name, :start_date])
     |> foreign_key_constraint(:lead_id)

--- a/lib/bike_brigade_web/live/program_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/program_live/form_component.html.heex
@@ -250,6 +250,12 @@
         />
 
         <.input type="checkbox" field={f[:active]} label="Active" />
+        <.input
+          :if={Phoenix.HTML.Form.input_value(f, :slack_channel_id) not in [nil, ""]}
+          type="checkbox"
+          field={f[:send_delivery_summaries]}
+          label="Send Campaign Delivery Summary to Slack"
+        />
       </div>
     </.inputs_for>
   </.simple_form>

--- a/priv/repo/migrations/20260512195708_add_send_delivery_summaries_to_programs.exs
+++ b/priv/repo/migrations/20260512195708_add_send_delivery_summaries_to_programs.exs
@@ -1,0 +1,9 @@
+defmodule BikeBrigade.Repo.Migrations.AddSendDeliverySummariesToPrograms do
+  use Ecto.Migration
+
+  def change do
+    alter table(:programs) do
+      add :send_delivery_summaries, :boolean, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260512195708_add_send_delivery_summaries_to_programs.exs
+++ b/priv/repo/migrations/20260512195708_add_send_delivery_summaries_to_programs.exs
@@ -3,7 +3,7 @@ defmodule BikeBrigade.Repo.Migrations.AddSendDeliverySummariesToPrograms do
 
   def change do
     alter table(:programs) do
-      add :send_delivery_summaries, :boolean, default: false, null: false
+      add :send_delivery_summaries, :boolean, default: false
     end
   end
 end

--- a/priv/repo/migrations/20260512195708_add_send_delivery_summaries_to_programs.exs
+++ b/priv/repo/migrations/20260512195708_add_send_delivery_summaries_to_programs.exs
@@ -3,7 +3,7 @@ defmodule BikeBrigade.Repo.Migrations.AddSendDeliverySummariesToPrograms do
 
   def change do
     alter table(:programs) do
-      add :send_delivery_summaries, :boolean, default: false
+      add :send_delivery_summaries, :boolean, default: false, null: false
     end
   end
 end

--- a/priv/repo/migrations/20260519000001_enable_send_delivery_summaries_for_programs_with_slack_channel.exs
+++ b/priv/repo/migrations/20260519000001_enable_send_delivery_summaries_for_programs_with_slack_channel.exs
@@ -5,11 +5,9 @@ defmodule BikeBrigade.Repo.Migrations.EnableSendDeliverySummariesForProgramsWith
   alias BikeBrigade.Repo
 
   def up do
-    from(prog in BikeBrigade.Delivery.Program,
-      update: [set: [send_delivery_summaries: true]],
-      where: not is_nil(prog.slack_channel_id)
-    )
-    |> Repo.update_all([])
+    execute """
+      UPDATE programs SET send_delivery_summaries = true WHERE slack_channel_id IS NOT NULL
+    """
   end
 
   def down, do: :ok

--- a/priv/repo/migrations/20260519000001_enable_send_delivery_summaries_for_programs_with_slack_channel.exs
+++ b/priv/repo/migrations/20260519000001_enable_send_delivery_summaries_for_programs_with_slack_channel.exs
@@ -1,0 +1,16 @@
+defmodule BikeBrigade.Repo.Migrations.EnableSendDeliverySummariesForProgramsWithSlackChannel do
+  use Ecto.Migration
+  import Ecto.Query
+
+  alias BikeBrigade.Repo
+
+  def up do
+    from(prog in BikeBrigade.Delivery.Program,
+      update: [set: [send_delivery_summaries: true]],
+      where: not is_nil(prog.slack_channel_id)
+    )
+    |> Repo.update_all([])
+  end
+
+  def down, do: :ok
+end

--- a/priv/repo/migrations/20260519000001_enable_send_delivery_summaries_for_programs_with_slack_channel.exs
+++ b/priv/repo/migrations/20260519000001_enable_send_delivery_summaries_for_programs_with_slack_channel.exs
@@ -1,8 +1,5 @@
 defmodule BikeBrigade.Repo.Migrations.EnableSendDeliverySummariesForProgramsWithSlackChannel do
   use Ecto.Migration
-  import Ecto.Query
-
-  alias BikeBrigade.Repo
 
   def up do
     execute """

--- a/priv/repo/migrations/20260526000001_add_not_null_constraint_to_send_delivery_summaries.exs
+++ b/priv/repo/migrations/20260526000001_add_not_null_constraint_to_send_delivery_summaries.exs
@@ -1,0 +1,9 @@
+defmodule BikeBrigade.Repo.Migrations.AddNotNullConstraintToSendDeliverySummaries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:programs) do
+      modify :send_delivery_summaries, :boolean, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260526000001_add_not_null_constraint_to_send_delivery_summaries.exs
+++ b/priv/repo/migrations/20260526000001_add_not_null_constraint_to_send_delivery_summaries.exs
@@ -1,9 +1,15 @@
 defmodule BikeBrigade.Repo.Migrations.AddNotNullConstraintToSendDeliverySummaries do
   use Ecto.Migration
 
-  def change do
+  def up do
     alter table(:programs) do
       modify :send_delivery_summaries, :boolean, null: false
+    end
+  end
+
+  def down do
+    alter table(:programs) do
+      modify :send_delivery_summaries, :boolean, null: true
     end
   end
 end


### PR DESCRIPTION
 ## Summary                           
                                       
  Make delivery summary posting optional per program, allowing programs to control whether campaign 
  delivery summaries are posted to their configured Slack channel.      
                                       
  ## Problem                           
                                       
  Previously, campaign delivery summaries were automatically posted to Slack whenever a program had a Slack channel configured. This didn't account for programs that may not want this automated notification,    
  creating unnecessary Slack traffic for some teams.                      
                                       
  ## Solution                          
                                       
  - Added `send_delivery_summaries` boolean field to programs (defaults to `false`)                          
  - Made the checkbox visible in the form only when a Slack channel is selected, preventing misconfiguration
  - Updated `CampaignSummaryPoster` to check this flag before posting summaries                            
                                       
  ## Changes                           
                                       
  **Backend:**                         
  - Added migration to add `send_delivery_summaries` column to `programs` table                     
  - Updated `Program` schema to include the new field                       
  - Modified `CampaignSummaryPoster.post_summary_for_campaign/1` to check the flag before posting              
  - Changed logging from warning to info when summaries are skipped due to the flag                          
                                       
  **Frontend:**                        
  - Added conditional checkbox in program form that only displays when a Slack channel is selected          
  - Uses `:if` directive to prevent showing the option when channel is not configured                       
                                       
  ## Note                           
                                       
  Programs that want delivery summaries need to explicitly enable the checkbox.


## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [X] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.
Opt-in delivery summaries: programs control whether campaign delivery summaries are posted to Slack channel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Slack delivery summaries opt-in per program to reduce unwanted Slack noise. Previously we posted whenever a program had a Slack channel; now we post only when `send_delivery_summaries` is enabled and a channel is set, and we log at info when skipping instead of sending Slack errors.

- Changes
  - Add `send_delivery_summaries` (default false) to programs; show the checkbox only when a Slack channel is selected.
  - Update `CampaignSummaryPoster` to require both the flag and channel before posting; log at info when skipped.
  - Preserve existing behavior by enabling the flag for programs that already have a Slack channel.

- Migration
  - Run the new migrations (add column, backfill true where `slack_channel_id` is set, add NOT NULL constraint).

<sup>Written for commit 6ff2bb238a19c71a48eb0d61bfce30aeb6224444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bikebrigade/dispatch/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting to control whether campaign delivery summaries are sent to Slack.
  * Programs can enable delivery summary notifications through a new checkbox, shown when a Slack channel is configured.
  * Campaign summaries are posted only when Slack is configured and delivery summaries are enabled.

* **Chores**
  * Existing programs with configured Slack channels have delivery summaries enabled by default.
  * Added safeguards to ensure this setting always has a valid value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->