### PR TITLE
Add Community Fridges CRUD and UI

### DIFF
--- a/lib/bike_brigade/delivery/program.ex
+++ b/lib/bike_brigade/delivery/program.ex
@@ -43,6 +43,7 @@ defmodule BikeBrigade.Delivery.Program do
     field :public, :boolean, default: false
     field :hide_pickup_address, :boolean, default: false
     field :slack_channel_id, :string
+    field :community_fridge, :boolean, default: false
 
     # TODO: this is me trying out virtual fields again
     field :campaign_count, :integer, virtual: true
@@ -80,7 +81,8 @@ defmodule BikeBrigade.Delivery.Program do
       :spreadsheet_layout,
       :start_date,
       :photo_description,
-      :photos
+      :photos,
+      :community_fridge
     ])
     |> validate_required([:name, :start_date])
     |> foreign_key_constraint(:lead_id)

--- a/lib/bike_brigade/delivery/task.ex
+++ b/lib/bike_brigade/delivery/task.ex
@@ -8,6 +8,7 @@ defmodule BikeBrigade.Delivery.Task do
   alias BikeBrigade.Riders.Rider
   alias BikeBrigade.Delivery.{Campaign, Item, TaskItem}
   alias BikeBrigade.Locations.Location
+  alias BikeBrigade.Locations.CommunityFridge
 
   defenum(DeliveryStatusEnum,
     pending: "pending",
@@ -26,7 +27,8 @@ defmodule BikeBrigade.Delivery.Task do
     :delivery_instructions,
     :signup_notes,
     :assigned_rider_id,
-    :campaign_id
+    :campaign_id,
+    :community_fridge_id
   ]
 
   @embedded_fields [
@@ -51,6 +53,7 @@ defmodule BikeBrigade.Delivery.Task do
 
     belongs_to :assigned_rider, Rider, on_replace: :nilify
     belongs_to :campaign, Campaign
+    belongs_to :community_fridge, CommunityFridge
     has_many :task_items, TaskItem, on_replace: :delete_if_exists
     many_to_many :items, Item, join_through: TaskItem
 

--- a/lib/bike_brigade/locations.ex
+++ b/lib/bike_brigade/locations.ex
@@ -1,6 +1,9 @@
 defmodule BikeBrigade.Locations do
+  import Ecto.Query, warn: false
+
   alias BikeBrigade.Repo
   alias BikeBrigade.Locations.Location
+  alias BikeBrigade.Locations.CommunityFridge
 
   def neighborhood(%Location{} = location) do
     if neighborhood = Repo.preload(location, :neighborhood).neighborhood do
@@ -12,5 +15,51 @@ defmodule BikeBrigade.Locations do
 
   def neighborhood(nil) do
     "Unknown"
+  end
+
+  @doc """
+  Returns the list of community_fridges.
+  """
+  def list_community_fridges do
+    Repo.all(CommunityFridge)
+  end
+
+  @doc """
+  Gets a single community_fridge.
+
+  Raises `Ecto.NoResultsError` if the Community fridge does not exist.
+  """
+  def get_community_fridge!(id), do: Repo.get!(CommunityFridge, id)
+
+  @doc """
+  Creates a community_fridge.
+  """
+  def create_community_fridge(attrs \\ %{}) do
+    %CommunityFridge{}
+    |> CommunityFridge.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a community_fridge.
+  """
+  def update_community_fridge(%CommunityFridge{} = community_fridge, attrs) do
+    community_fridge
+    |> CommunityFridge.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a community_fridge.
+  """
+  def delete_community_fridge(%CommunityFridge{} = community_fridge) do
+    Repo.delete(community_fridge)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking community_fridge changes.
+  """
+  def change_community_fridge(%CommunityFridge{} = community_fridge, attrs \\ %{}) do
+    CommunityFridge.changeset(community_fridge, attrs)
   end
 end

--- a/lib/bike_brigade/locations.ex
+++ b/lib/bike_brigade/locations.ex
@@ -21,7 +21,7 @@ defmodule BikeBrigade.Locations do
   Returns the list of community_fridges.
   """
   def list_community_fridges do
-    Repo.all(CommunityFridge)
+    Repo.all(from cf in CommunityFridge, order_by: [desc: cf.active, asc: cf.name])
   end
 
   @doc """

--- a/lib/bike_brigade/locations/community_fridge.ex
+++ b/lib/bike_brigade/locations/community_fridge.ex
@@ -22,7 +22,7 @@ defmodule BikeBrigade.Locations.CommunityFridge do
   def changeset(community_fridge, attrs) do
     community_fridge
     |> cast(attrs, [:name, :description, :photo, :active, :pair_preferred, :location_id])
-    |> validate_required([:name, :location_id])
+    |> validate_required([:name])
     |> assoc_constraint(:location)
   end
 end

--- a/lib/bike_brigade/locations/community_fridge.ex
+++ b/lib/bike_brigade/locations/community_fridge.ex
@@ -21,7 +21,8 @@ defmodule BikeBrigade.Locations.CommunityFridge do
   @doc false
   def changeset(community_fridge, attrs) do
     community_fridge
-    |> cast(attrs, [:name, :description, :photo, :active, :pair_preferred])
-    |> validate_required([:name])
+    |> cast(attrs, [:name, :description, :photo, :active, :pair_preferred, :location_id])
+    |> validate_required([:name, :location_id])
+    |> assoc_constraint(:location)
   end
 end

--- a/lib/bike_brigade/locations/community_fridge.ex
+++ b/lib/bike_brigade/locations/community_fridge.ex
@@ -3,6 +3,7 @@ defmodule BikeBrigade.Locations.CommunityFridge do
   import Ecto.Changeset
 
   alias BikeBrigade.Locations.Location
+  alias BikeBrigade.Delivery.Task
 
   schema "community_fridges" do
     field :active, :boolean, default: true
@@ -11,6 +12,8 @@ defmodule BikeBrigade.Locations.CommunityFridge do
     field :photo, :string
     field :pair_preferred, :boolean, default: false
     belongs_to :location, Location
+
+    has_many :tasks, Task
 
     timestamps()
   end

--- a/lib/bike_brigade/locations/community_fridge.ex
+++ b/lib/bike_brigade/locations/community_fridge.ex
@@ -1,0 +1,24 @@
+defmodule BikeBrigade.Locations.CommunityFridge do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias BikeBrigade.Locations.Location
+
+  schema "community_fridges" do
+    field :active, :boolean, default: true
+    field :name, :string
+    field :description, :string
+    field :photo, :string
+    field :pair_preferred, :boolean, default: false
+    belongs_to :location, Location
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(community_fridge, attrs) do
+    community_fridge
+    |> cast(attrs, [:name, :description, :photo, :active, :pair_preferred])
+    |> validate_required([:name])
+  end
+end

--- a/lib/bike_brigade/locations/location.ex
+++ b/lib/bike_brigade/locations/location.ex
@@ -7,6 +7,7 @@ defmodule BikeBrigade.Locations.Location do
 
   alias BikeBrigade.Riders.Rider
   alias BikeBrigade.Delivery.{Campaign, Opportunity, Task}
+  alias BikeBrigade.Locations.CommunityFridge
 
   @fields [:coords, :address, :city, :postal, :province, :country, :unit, :buzzer]
   @user_provided_fields [:address, :unit, :buzzer]
@@ -29,6 +30,7 @@ defmodule BikeBrigade.Locations.Location do
     has_one :task_dropoff, Task, foreign_key: :dropoff_location_id, on_delete: :nilify_all
     has_one :task_pickup, Task, foreign_key: :pickup_location_id, on_delete: :nilify_all
     has_one :opportunity, Opportunity, on_delete: :nilify_all
+    has_one :community_fridge, CommunityFridge, on_delete: :nilify_all
 
     timestamps()
   end

--- a/lib/bike_brigade_web/components/layouts.ex
+++ b/lib/bike_brigade_web/components/layouts.ex
@@ -105,6 +105,15 @@ defmodule BikeBrigadeWeb.Layouts do
           </:icon>
           Tags
         </.sidebar_link>
+        <.sidebar_link
+          selected={@current_page == :community_fridges}
+          navigate={~p"/community_fridges"}
+        >
+          <:icon>
+            <Heroicons.archive_box />
+          </:icon>
+          Community Fridges
+        </.sidebar_link>
       </div>
 
       <.rider_links is_rider={@is_rider} is_dispatcher={@is_dispatcher} current_page={@current_page} />

--- a/lib/bike_brigade_web/live/community_fridge_live/form_component.ex
+++ b/lib/bike_brigade_web/live/community_fridge_live/form_component.ex
@@ -1,0 +1,58 @@
+defmodule BikeBrigadeWeb.CommunityFridgeLive.FormComponent do
+  use BikeBrigadeWeb, :live_component
+
+  alias BikeBrigade.Locations
+
+  @impl true
+  def update(%{community_fridge: community_fridge} = assigns, socket) do
+    changeset = Locations.change_community_fridge(community_fridge)
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:changeset, changeset)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"community_fridge" => community_fridge_params}, socket) do
+    changeset =
+      socket.assigns.community_fridge
+      |> Locations.change_community_fridge(community_fridge_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :changeset, changeset)}
+  end
+
+  def handle_event("save", %{"community_fridge" => community_fridge_params}, socket) do
+    save_community_fridge(socket, socket.assigns.action, community_fridge_params)
+  end
+
+  defp save_community_fridge(socket, :edit, community_fridge_params) do
+    case Locations.update_community_fridge(
+           socket.assigns.community_fridge,
+           community_fridge_params
+         ) do
+      {:ok, _community_fridge} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Community fridge updated successfully")
+         |> push_navigate(to: socket.assigns.navigate)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :changeset, changeset)}
+    end
+  end
+
+  defp save_community_fridge(socket, :new, community_fridge_params) do
+    case Locations.create_community_fridge(community_fridge_params) do
+      {:ok, _community_fridge} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Community fridge created successfully")
+         |> push_navigate(to: socket.assigns.navigate)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+end

--- a/lib/bike_brigade_web/live/community_fridge_live/form_component.html.heex
+++ b/lib/bike_brigade_web/live/community_fridge_live/form_component.html.heex
@@ -1,0 +1,20 @@
+<div>
+  <.header>{@title}</.header>
+  <.simple_form
+    :let={f}
+    for={@changeset}
+    id="community-fridge-form"
+    phx-target={@myself}
+    phx-change="validate"
+    phx-submit="save"
+  >
+    <.input type="text" field={f[:name]} label="Name" />
+    <.input type="textarea" field={f[:description]} label="Description" />
+    <.input type="checkbox" field={f[:pair_preferred]} label="Pair Preferred" />
+    <.input type="checkbox" field={f[:active]} label="Active" />
+
+    <:actions>
+      <.button type="submit" phx-disable-with="Saving...">Save</.button>
+    </:actions>
+  </.simple_form>
+</div>

--- a/lib/bike_brigade_web/live/community_fridge_live/index.ex
+++ b/lib/bike_brigade_web/live/community_fridge_live/index.ex
@@ -1,0 +1,49 @@
+defmodule BikeBrigadeWeb.CommunityFridgeLive.Index do
+  use BikeBrigadeWeb, :live_view
+
+  alias BikeBrigade.Locations
+  alias BikeBrigade.Locations.CommunityFridge
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page, :community_fridges)
+     |> assign(:community_fridges, list_community_fridges())}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Edit Community Fridge")
+    |> assign(:community_fridge, Locations.get_community_fridge!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "New Community Fridge")
+    |> assign(:community_fridge, %CommunityFridge{})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Community Fridges")
+    |> assign(:community_fridge, nil)
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    community_fridge = Locations.get_community_fridge!(id)
+    {:ok, _} = Locations.delete_community_fridge(community_fridge)
+
+    {:noreply, assign(socket, :community_fridges, list_community_fridges())}
+  end
+
+  defp list_community_fridges do
+    Locations.list_community_fridges()
+  end
+end

--- a/lib/bike_brigade_web/live/community_fridge_live/index.ex
+++ b/lib/bike_brigade_web/live/community_fridge_live/index.ex
@@ -35,14 +35,6 @@ defmodule BikeBrigadeWeb.CommunityFridgeLive.Index do
     |> assign(:community_fridge, nil)
   end
 
-  @impl true
-  def handle_event("delete", %{"id" => id}, socket) do
-    community_fridge = Locations.get_community_fridge!(id)
-    {:ok, _} = Locations.delete_community_fridge(community_fridge)
-
-    {:noreply, assign(socket, :community_fridges, list_community_fridges())}
-  end
-
   defp list_community_fridges do
     Locations.list_community_fridges()
   end

--- a/lib/bike_brigade_web/live/community_fridge_live/index.html.heex
+++ b/lib/bike_brigade_web/live/community_fridge_live/index.html.heex
@@ -24,15 +24,6 @@
       Edit
     </.link>
   </:action>
-  <:action :let={community_fridge}>
-    <.link
-      phx-click={JS.push("delete", value: %{id: community_fridge.id})}
-      data-confirm={"Are you sure you want to delete \"#{community_fridge.name}\"?"}
-      class="link"
-    >
-      Delete
-    </.link>
-  </:action>
 </.table>
 
 <.modal

--- a/lib/bike_brigade_web/live/community_fridge_live/index.html.heex
+++ b/lib/bike_brigade_web/live/community_fridge_live/index.html.heex
@@ -1,0 +1,52 @@
+<.header>
+  Community Fridges
+  <:actions>
+    <.button patch={~p"/community_fridges/new"}>New Community Fridge</.button>
+  </:actions>
+</.header>
+
+<.table id="community_fridges" rows={@community_fridges}>
+  <:col :let={community_fridge} label="Name">
+    {community_fridge.name}
+  </:col>
+  <:col :let={community_fridge} label="Description">
+    {community_fridge.description}
+  </:col>
+  <:col :let={community_fridge} label="Pair Preferred">
+    {if community_fridge.pair_preferred, do: "Yes", else: "No"}
+  </:col>
+  <:col :let={community_fridge} label="Active">
+    {if community_fridge.active, do: "Yes", else: "No"}
+  </:col>
+
+  <:action :let={community_fridge}>
+    <.link patch={~p"/community_fridges/#{community_fridge.id}/edit"} class="link">
+      Edit
+    </.link>
+  </:action>
+  <:action :let={community_fridge}>
+    <.link
+      phx-click={JS.push("delete", value: %{id: community_fridge.id})}
+      data-confirm={"Are you sure you want to delete \"#{community_fridge.name}\"?"}
+      class="link"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
+
+<.modal
+  :if={@live_action in [:new, :edit]}
+  id="community-fridge-modal"
+  show
+  on_cancel={JS.navigate(~p"/community_fridges")}
+>
+  <.live_component
+    module={BikeBrigadeWeb.CommunityFridgeLive.FormComponent}
+    id={@community_fridge.id || :new}
+    action={@live_action}
+    title={@page_title}
+    community_fridge={@community_fridge}
+    navigate={~p"/community_fridges"}
+  />
+</.modal>

--- a/lib/bike_brigade_web/router.ex
+++ b/lib/bike_brigade_web/router.ex
@@ -179,6 +179,10 @@ defmodule BikeBrigadeWeb.Router do
       live "/tags/new", TagLive.Index, :new
       live "/tags/:id/edit", TagLive.Index, :edit
 
+      live "/community_fridges", CommunityFridgeLive.Index, :index
+      live "/community_fridges/new", CommunityFridgeLive.Index, :new
+      live "/community_fridges/:id/edit", CommunityFridgeLive.Index, :edit
+
       live "/delivery_notes", DeliveryNoteLive.Index, :index
     end
 

--- a/priv/repo/migrations/20260528193717_create_community_fridges.exs
+++ b/priv/repo/migrations/20260528193717_create_community_fridges.exs
@@ -1,0 +1,18 @@
+defmodule BikeBrigade.Repo.Migrations.CreateCommunityFridges do
+  use Ecto.Migration
+
+  def change do
+    create table(:community_fridges) do
+      add :name, :string
+      add :description, :text
+      add :photo, :string
+      add :active, :boolean, default: true, null: false
+      add :pair_preferred, :boolean, default: false, null: false
+      add :location_id, references(:locations, on_delete: :nilify_all)
+
+      timestamps()
+    end
+
+    create index(:community_fridges, [:location_id])
+  end
+end

--- a/priv/repo/migrations/20260528193717_create_community_fridges.exs
+++ b/priv/repo/migrations/20260528193717_create_community_fridges.exs
@@ -12,7 +12,5 @@ defmodule BikeBrigade.Repo.Migrations.CreateCommunityFridges do
 
       timestamps()
     end
-
-    create index(:community_fridges, [:location_id])
   end
 end

--- a/priv/repo/migrations/20260528195913_add_community_fridge_to_programs.exs
+++ b/priv/repo/migrations/20260528195913_add_community_fridge_to_programs.exs
@@ -1,0 +1,9 @@
+defmodule BikeBrigade.Repo.Migrations.AddCommunityFridgeToPrograms do
+  use Ecto.Migration
+
+  def change do
+    alter table(:programs) do
+      add :community_fridge, :boolean, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260528200000_add_community_fridge_to_tasks.exs
+++ b/priv/repo/migrations/20260528200000_add_community_fridge_to_tasks.exs
@@ -1,0 +1,9 @@
+defmodule BikeBrigade.Repo.Migrations.AddCommunityFridgeToTasks do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tasks) do
+      add :community_fridge_id, references(:community_fridges), null: true
+    end
+  end
+end

--- a/priv/repo/migrations/20260528200000_add_community_fridge_to_tasks.exs
+++ b/priv/repo/migrations/20260528200000_add_community_fridge_to_tasks.exs
@@ -5,5 +5,7 @@ defmodule BikeBrigade.Repo.Migrations.AddCommunityFridgeToTasks do
     alter table(:tasks) do
       add :community_fridge_id, references(:community_fridges), null: true
     end
+
+    create index(:tasks, [:community_fridge_id])
   end
 end

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -377,6 +377,20 @@ defmodule BikeBrigade.DeliveryTest do
     end
   end
 
+  describe "Program community_fridge field" do
+    test "program defaults community_fridge to false" do
+      program = fixture(:program)
+
+      assert program.community_fridge == false
+    end
+
+    test "program can be created with community_fridge true" do
+      program = fixture(:program, %{community_fridge: true})
+
+      assert program.community_fridge == true
+    end
+  end
+
   def item_name(%Task{task_items: [%{item: %{name: item_name}}]}), do: item_name
 
   defp get_utc_now(), do: NaiveDateTime.utc_now()

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -391,6 +391,22 @@ defmodule BikeBrigade.DeliveryTest do
     end
   end
 
+  describe "Task community_fridge_id field" do
+    test "task defaults community_fridge_id to nil" do
+      campaign = fixture(:campaign)
+      task = fixture(:task, %{campaign: campaign})
+
+      assert task.community_fridge_id == nil
+    end
+
+    test "task can be created with community_fridge_id" do
+      campaign = fixture(:campaign)
+      task = fixture(:task, %{campaign: campaign, community_fridge_id: 123})
+
+      assert task.community_fridge_id == 123
+    end
+  end
+
   def item_name(%Task{task_items: [%{item: %{name: item_name}}]}), do: item_name
 
   defp get_utc_now(), do: NaiveDateTime.utc_now()

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -401,9 +401,10 @@ defmodule BikeBrigade.DeliveryTest do
 
     test "task can be created with community_fridge_id" do
       campaign = fixture(:campaign)
-      task = fixture(:task, %{campaign: campaign, community_fridge_id: 123})
+      community_fridge = fixture(:community_fridge)
+      task = fixture(:task, %{campaign: campaign, community_fridge_id: community_fridge.id})
 
-      assert task.community_fridge_id == 123
+      assert task.community_fridge_id == community_fridge.id
     end
   end
 

--- a/test/bike_brigade/locations/community_fridge_test.exs
+++ b/test/bike_brigade/locations/community_fridge_test.exs
@@ -65,18 +65,6 @@ defmodule BikeBrigade.Locations.CommunityFridgeTest do
       assert "can't be blank" in errors_on(changeset).name
     end
 
-    test "changeset validates location_id is required" do
-      attrs = %{
-        name: "Fridge Without Location",
-        description: "Missing location_id"
-      }
-
-      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
-
-      refute changeset.valid?
-      assert "can't be blank" in errors_on(changeset).location_id
-    end
-
     test "changeset sets default values for active and pair_preferred", %{location: location} do
       attrs = %{
         name: "Fridge with Defaults",

--- a/test/bike_brigade/locations/community_fridge_test.exs
+++ b/test/bike_brigade/locations/community_fridge_test.exs
@@ -1,0 +1,92 @@
+defmodule BikeBrigade.Locations.CommunityFridgeTest do
+  use BikeBrigade.DataCase
+
+  alias BikeBrigade.Locations.CommunityFridge
+
+  setup do
+    location_data = fixture(:location)
+
+    {:ok, location} =
+      %BikeBrigade.Locations.Location{}
+      |> BikeBrigade.Locations.Location.changeset(location_data)
+      |> Repo.insert()
+
+    %{location: location}
+  end
+
+  describe "CommunityFridge changeset" do
+    test "changeset with valid attributes", %{location: location} do
+      attrs = %{
+        name: "Downtown Community Fridge",
+        description: "A fridge for the community",
+        photo: "https://example.com/photo.jpg",
+        active: true,
+        pair_preferred: false,
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      assert changeset.valid?
+    end
+
+    test "changeset with minimal required attributes", %{location: location} do
+      attrs = %{
+        name: "Community Fridge",
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      assert changeset.valid?
+    end
+
+    test "changeset requires name", %{location: location} do
+      attrs = %{
+        description: "A fridge without a name",
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).name
+    end
+
+    test "changeset rejects empty name", %{location: location} do
+      attrs = %{
+        name: "",
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).name
+    end
+
+    test "changeset validates location_id is required" do
+      attrs = %{
+        name: "Fridge Without Location",
+        description: "Missing location_id"
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).location_id
+    end
+
+    test "changeset sets default values for active and pair_preferred", %{location: location} do
+      attrs = %{
+        name: "Fridge with Defaults",
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      assert Ecto.Changeset.get_field(changeset, :active) == true
+      assert Ecto.Changeset.get_field(changeset, :pair_preferred) == false
+    end
+  end
+end

--- a/test/bike_brigade/locations_test.exs
+++ b/test/bike_brigade/locations_test.exs
@@ -1,0 +1,90 @@
+defmodule BikeBrigade.LocationsTest do
+  use BikeBrigade.DataCase
+
+  alias BikeBrigade.Locations
+
+  describe "community_fridges" do
+    alias BikeBrigade.Locations.CommunityFridge
+
+    import BikeBrigade.LocationsFixtures
+
+    @invalid_attrs %{active: nil, name: nil, description: nil, photo: nil, pair_preferred: nil}
+
+    test "list_community_fridges/0 returns all community_fridges" do
+      community_fridge = community_fridge_fixture()
+      assert Locations.list_community_fridges() == [community_fridge]
+    end
+
+    test "get_community_fridge!/1 returns the community_fridge with given id" do
+      community_fridge = community_fridge_fixture()
+      assert Locations.get_community_fridge!(community_fridge.id) == community_fridge
+    end
+
+    test "create_community_fridge/1 with valid data creates a community_fridge" do
+      valid_attrs = %{
+        active: true,
+        name: "some name",
+        description: "some description",
+        photo: "some photo",
+        pair_preferred: true
+      }
+
+      assert {:ok, %CommunityFridge{} = community_fridge} =
+               Locations.create_community_fridge(valid_attrs)
+
+      assert community_fridge.active == true
+      assert community_fridge.name == "some name"
+      assert community_fridge.description == "some description"
+      assert community_fridge.photo == "some photo"
+      assert community_fridge.pair_preferred == true
+    end
+
+    test "create_community_fridge/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Locations.create_community_fridge(@invalid_attrs)
+    end
+
+    test "update_community_fridge/2 with valid data updates the community_fridge" do
+      community_fridge = community_fridge_fixture()
+
+      update_attrs = %{
+        active: false,
+        name: "some updated name",
+        description: "some updated description",
+        photo: "some updated photo",
+        pair_preferred: false
+      }
+
+      assert {:ok, %CommunityFridge{} = community_fridge} =
+               Locations.update_community_fridge(community_fridge, update_attrs)
+
+      assert community_fridge.active == false
+      assert community_fridge.name == "some updated name"
+      assert community_fridge.description == "some updated description"
+      assert community_fridge.photo == "some updated photo"
+      assert community_fridge.pair_preferred == false
+    end
+
+    test "update_community_fridge/2 with invalid data returns error changeset" do
+      community_fridge = community_fridge_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               Locations.update_community_fridge(community_fridge, @invalid_attrs)
+
+      assert community_fridge == Locations.get_community_fridge!(community_fridge.id)
+    end
+
+    test "delete_community_fridge/1 deletes the community_fridge" do
+      community_fridge = community_fridge_fixture()
+      assert {:ok, %CommunityFridge{}} = Locations.delete_community_fridge(community_fridge)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Locations.get_community_fridge!(community_fridge.id)
+      end
+    end
+
+    test "change_community_fridge/1 returns a community_fridge changeset" do
+      community_fridge = community_fridge_fixture()
+      assert %Ecto.Changeset{} = Locations.change_community_fridge(community_fridge)
+    end
+  end
+end

--- a/test/bike_brigade/locations_test.exs
+++ b/test/bike_brigade/locations_test.exs
@@ -12,7 +12,19 @@ defmodule BikeBrigade.LocationsTest do
 
     test "list_community_fridges/0 returns all community_fridges" do
       community_fridge = community_fridge_fixture()
-      assert Locations.list_community_fridges() == [community_fridge]
+      assert community_fridge.id in Enum.map(Locations.list_community_fridges(), & &1.id)
+    end
+
+    test "list_community_fridges/0 returns active fridges first then alphabetically by name" do
+      inactive = community_fridge_fixture(%{name: "Alpha", active: false})
+      active_b = community_fridge_fixture(%{name: "Beta", active: true})
+      active_a = community_fridge_fixture(%{name: "Alpha", active: true})
+
+      assert Enum.map(Locations.list_community_fridges(), & &1.id) == [
+               active_a.id,
+               active_b.id,
+               inactive.id
+             ]
     end
 
     test "get_community_fridge!/1 returns the community_fridge with given id" do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -186,6 +186,38 @@ defmodule BikeBrigade.Fixtures do
     Toronto.random_location()
   end
 
+  def fixture(:community_fridge, attrs) do
+    # Ensure we have a location_id
+    attrs =
+      attrs
+      |> Map.put_new_lazy(:location_id, fn ->
+        location_data = fixture(:location)
+
+        {:ok, location} =
+          %BikeBrigade.Locations.Location{}
+          |> BikeBrigade.Locations.Location.changeset(location_data)
+          |> Repo.insert()
+
+        location.id
+      end)
+
+    {:ok, fridge} =
+      %BikeBrigade.Locations.CommunityFridge{}
+      |> BikeBrigade.Locations.CommunityFridge.changeset(
+        %{
+          name: "Community Fridge #{System.unique_integer([:positive])}",
+          description: "A community fridge for the neighborhood",
+          active: true,
+          pair_preferred: false
+        }
+        |> Map.merge(attrs)
+      )
+      |> Repo.insert()
+
+    fridge
+    |> Repo.preload(:location)
+  end
+
   def fixture(:sms_message_from_rider, rider),
     do: fixture(:sms_message_from_rider, rider, %{})
 

--- a/test/support/fixtures/locations_fixtures.ex
+++ b/test/support/fixtures/locations_fixtures.ex
@@ -1,0 +1,24 @@
+defmodule BikeBrigade.LocationsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `BikeBrigade.Locations` context.
+  """
+
+  @doc """
+  Generate a community_fridge.
+  """
+  def community_fridge_fixture(attrs \\ %{}) do
+    {:ok, community_fridge} =
+      attrs
+      |> Enum.into(%{
+        active: true,
+        description: "some description",
+        name: "some name",
+        pair_preferred: true,
+        photo: "some photo"
+      })
+      |> BikeBrigade.Locations.create_community_fridge()
+
+    community_fridge
+  end
+end


### PR DESCRIPTION
## Builds on top of the community fridges data model by wiring up the full management interface.

  What's included

  Context (BikeBrigade.Locations)
  - list_community_fridges/0, get_community_fridge!/1,
  create_community_fridge/1, update_community_fridge/2,
  delete_community_fridge/1, change_community_fridge/2
  
  LiveView UI (CommunityFridgeLive)
  - Index page listing all fridges (name, description, pair preferred,
  active status) with Edit and Delete actions
  - New/Edit modal backed by a form component with live validation
  - Routes: GET /community_fridges, /community_fridges/new,
  /community_fridges/:id/edit
  - Sidebar nav entry under the admin section using the archive_box icon

  Tests
  - Full CRUD coverage in BikeBrigade.LocationsTest (list, get, create
  valid/invalid, update valid/invalid, delete, changeset)
  - BikeBrigade.LocationsFixtures helper module


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Community Fridges as a first-class resource with CRUD in Locations and an admin LiveView. Previously there was no fridge model or UI; now admins can create and edit fridges, and the index orders active fridges first then by name. The Delete action is not shown in the UI; context delete remains available.

- Schema: `Locations.CommunityFridge` (name, description, photo, active, pair_preferred) with `belongs_to :location` and `has_many :tasks`; default ordering active desc, name asc.
- Context: `list/get/create/update/delete/change` functions in `Locations`.
- Admin UI: `/community_fridges` index with New/Edit modal (live validation), sidebar nav; no Delete action.
- Program: new `community_fridge` boolean flag (default false).
- Task: optional `community_fridge_id` FK with index and association.
- Tests: schema and context CRUD, new fields, and sort order coverage; fixtures updated.

**Rollout**
- Run database migrations.
- No backfill required; existing Programs remain `community_fridge: false`; Tasks keep `community_fridge_id: nil`.
- Verify admins can create and edit a fridge; confirm list ordering and that Delete is not available in the UI.

<sup>Written for commit 7b59b4e5c9b14f11845a4b35b910227bece439e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bikebrigade/dispatch/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Community Fridges management for dispatchers, including listing, creating, and editing.
  * Added Community Fridges navigation and authenticated routes.
  * Added support for linking deliveries and programs to community fridges.
  * Community Fridges support names, descriptions, active status, pairing preferences, and locations.
* **Bug Fixes**
  * Community fridge lists now prioritize active fridges and sort them by name.
* **Tests**
  * Added coverage for Community Fridge validation, management, and delivery associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->