### PR TITLE
Add community fridges data model

### DIFF
--- a/lib/bike_brigade/locations/community_fridge.ex
+++ b/lib/bike_brigade/locations/community_fridge.ex
@@ -1,0 +1,33 @@
+defmodule BikeBrigade.Locations.CommunityFridge do
+  use BikeBrigade.Schema
+  import Ecto.Changeset
+
+  alias BikeBrigade.Locations.Location
+
+  @fields [
+    :name,
+    :description,
+    :photo,
+    :active,
+    :pair_preferred
+  ]
+
+  schema "community_fridges" do
+    field :name, :string
+    field :description, :string
+    field :photo, :string
+    field :active, :boolean, default: true
+    field :pair_preferred, :boolean, default: false
+
+    belongs_to :location, Location
+
+    timestamps()
+  end
+
+  def changeset(community_fridge, attrs) do
+    community_fridge
+    |> cast(attrs, @fields ++ [:location_id])
+    |> validate_required([:name])
+    |> assoc_constraint(:location)
+  end
+end

--- a/lib/bike_brigade/locations/community_fridge.ex
+++ b/lib/bike_brigade/locations/community_fridge.ex
@@ -27,7 +27,7 @@ defmodule BikeBrigade.Locations.CommunityFridge do
   def changeset(community_fridge, params) do
     community_fridge
     |> cast(params, @fields ++ [:location_id])
-    |> validate_required([:name])
+    |> validate_required([:name, :location_id])
     |> assoc_constraint(:location)
   end
 end

--- a/lib/bike_brigade/locations/community_fridge.ex
+++ b/lib/bike_brigade/locations/community_fridge.ex
@@ -24,9 +24,9 @@ defmodule BikeBrigade.Locations.CommunityFridge do
     timestamps()
   end
 
-  def changeset(community_fridge, attrs) do
+  def changeset(community_fridge, params) do
     community_fridge
-    |> cast(attrs, @fields ++ [:location_id])
+    |> cast(params, @fields ++ [:location_id])
     |> validate_required([:name])
     |> assoc_constraint(:location)
   end

--- a/lib/bike_brigade/locations/community_fridge.ex
+++ b/lib/bike_brigade/locations/community_fridge.ex
@@ -28,6 +28,7 @@ defmodule BikeBrigade.Locations.CommunityFridge do
     community_fridge
     |> cast(params, @fields ++ [:location_id])
     |> validate_required([:name, :location_id])
+    |> unique_constraint(:location_id)
     |> assoc_constraint(:location)
   end
 end

--- a/lib/bike_brigade/locations/location.ex
+++ b/lib/bike_brigade/locations/location.ex
@@ -4,6 +4,7 @@ defmodule BikeBrigade.Locations.Location do
 
   alias BikeBrigade.Geocoder
   alias BikeBrigade.Locations.LocationNeighborhood
+  alias BikeBrigade.Locations.CommunityFridge
 
   alias BikeBrigade.Riders.Rider
   alias BikeBrigade.Delivery.{Campaign, Opportunity, Task}
@@ -29,6 +30,7 @@ defmodule BikeBrigade.Locations.Location do
     has_one :task_dropoff, Task, foreign_key: :dropoff_location_id, on_delete: :nilify_all
     has_one :task_pickup, Task, foreign_key: :pickup_location_id, on_delete: :nilify_all
     has_one :opportunity, Opportunity, on_delete: :nilify_all
+    has_one :community_fridge, CommunityFridge, on_delete: :nilify_all
 
     timestamps()
   end

--- a/priv/repo/migrations/20260825183237_add_community_fridges_table.exs
+++ b/priv/repo/migrations/20260825183237_add_community_fridges_table.exs
@@ -1,0 +1,16 @@
+defmodule BikeBrigade.Repo.Migrations.AddCommunityFridgesTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:community_fridges) do
+      add :name, :string
+      add :description, :text
+      add :photo, :string
+      add :active, :boolean, default: true, null: false
+      add :pair_preferred, :boolean, default: false, null: false
+      add :location_id, references(:locations, on_delete: :nilify_all)
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20260825183237_add_community_fridges_table.exs
+++ b/priv/repo/migrations/20260825183237_add_community_fridges_table.exs
@@ -3,7 +3,7 @@ defmodule BikeBrigade.Repo.Migrations.AddCommunityFridgesTable do
 
   def change do
     create table(:community_fridges) do
-      add :name, :string
+      add :name, :string, null: false
       add :description, :text
       add :photo, :string
       add :active, :boolean, default: true, null: false
@@ -12,5 +12,7 @@ defmodule BikeBrigade.Repo.Migrations.AddCommunityFridgesTable do
 
       timestamps()
     end
+
+    create unique_index(:community_fridges, [:location_id])
   end
 end

--- a/test/bike_brigade/locations/community_fridge_test.exs
+++ b/test/bike_brigade/locations/community_fridge_test.exs
@@ -31,7 +31,7 @@ defmodule BikeBrigade.Locations.CommunityFridgeTest do
       assert changeset.valid?
     end
 
-    test "changeset with minimal required attributes and default values", %{location: location} do
+    test "changeset with minimal required attributes", %{location: location} do
       attrs = %{
         name: "Community Fridge",
         location_id: location.id
@@ -40,8 +40,6 @@ defmodule BikeBrigade.Locations.CommunityFridgeTest do
       changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
 
       assert changeset.valid?
-      assert Ecto.Changeset.get_field(changeset, :active) == true
-      assert Ecto.Changeset.get_field(changeset, :pair_preferred) == false
     end
 
     test "changeset requires name", %{location: location} do

--- a/test/bike_brigade/locations/community_fridge_test.exs
+++ b/test/bike_brigade/locations/community_fridge_test.exs
@@ -1,0 +1,80 @@
+defmodule BikeBrigade.Locations.CommunityFridgeTest do
+  use BikeBrigade.DataCase
+
+  alias BikeBrigade.Locations.CommunityFridge
+
+  setup do
+    location_data = fixture(:location)
+
+    {:ok, location} =
+      %BikeBrigade.Locations.Location{}
+      |> BikeBrigade.Locations.Location.changeset(location_data)
+      |> Repo.insert()
+
+    %{location: location}
+  end
+
+  describe "CommunityFridge changeset" do
+    test "changeset with valid attributes", %{location: location} do
+      attrs = %{
+        name: "Downtown Community Fridge",
+        description: "A fridge for the community",
+        photo: "https://example.com/photo.jpg",
+        active: true,
+        pair_preferred: false,
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      assert changeset.valid?
+    end
+
+    test "changeset with minimal required attributes", %{location: location} do
+      attrs = %{
+        name: "Community Fridge",
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      assert changeset.valid?
+    end
+
+    test "changeset requires name", %{location: location} do
+      attrs = %{
+        description: "A fridge without a name",
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).name
+    end
+
+    test "changeset rejects empty name", %{location: location} do
+      attrs = %{
+        name: "",
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).name
+    end
+
+    test "changeset sets default values for active and pair_preferred", %{location: location} do
+      attrs = %{
+        name: "Fridge with Defaults",
+        location_id: location.id
+      }
+
+      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
+
+      assert Ecto.Changeset.get_field(changeset, :active) == true
+      assert Ecto.Changeset.get_field(changeset, :pair_preferred) == false
+    end
+  end
+end

--- a/test/bike_brigade/locations/community_fridge_test.exs
+++ b/test/bike_brigade/locations/community_fridge_test.exs
@@ -1,14 +1,15 @@
 defmodule BikeBrigade.Locations.CommunityFridgeTest do
   use BikeBrigade.DataCase
 
+  alias BikeBrigade.Locations.Location
   alias BikeBrigade.Locations.CommunityFridge
 
   setup do
     location_data = fixture(:location)
 
     {:ok, location} =
-      %BikeBrigade.Locations.Location{}
-      |> BikeBrigade.Locations.Location.changeset(location_data)
+      %Location{}
+      |> Location.changeset(location_data)
       |> Repo.insert()
 
     %{location: location}
@@ -30,7 +31,7 @@ defmodule BikeBrigade.Locations.CommunityFridgeTest do
       assert changeset.valid?
     end
 
-    test "changeset with minimal required attributes", %{location: location} do
+    test "changeset with minimal required attributes and default values", %{location: location} do
       attrs = %{
         name: "Community Fridge",
         location_id: location.id
@@ -39,6 +40,8 @@ defmodule BikeBrigade.Locations.CommunityFridgeTest do
       changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
 
       assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :active) == true
+      assert Ecto.Changeset.get_field(changeset, :pair_preferred) == false
     end
 
     test "changeset requires name", %{location: location} do
@@ -63,18 +66,6 @@ defmodule BikeBrigade.Locations.CommunityFridgeTest do
 
       refute changeset.valid?
       assert "can't be blank" in errors_on(changeset).name
-    end
-
-    test "changeset sets default values for active and pair_preferred", %{location: location} do
-      attrs = %{
-        name: "Fridge with Defaults",
-        location_id: location.id
-      }
-
-      changeset = CommunityFridge.changeset(%CommunityFridge{}, attrs)
-
-      assert Ecto.Changeset.get_field(changeset, :active) == true
-      assert Ecto.Changeset.get_field(changeset, :pair_preferred) == false
     end
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -186,6 +186,38 @@ defmodule BikeBrigade.Fixtures do
     Toronto.random_location()
   end
 
+  def fixture(:community_fridge, attrs) do
+    # Ensure we have a location_id
+    attrs =
+      attrs
+      |> Map.put_new_lazy(:location_id, fn ->
+        location_data = fixture(:location)
+
+        {:ok, location} =
+          %BikeBrigade.Locations.Location{}
+          |> BikeBrigade.Locations.Location.changeset(location_data)
+          |> Repo.insert()
+
+        location.id
+      end)
+
+    {:ok, fridge} =
+      %BikeBrigade.Locations.CommunityFridge{}
+      |> BikeBrigade.Locations.CommunityFridge.changeset(
+        %{
+          name: "Community Fridge #{System.unique_integer([:positive])}",
+          description: "A community fridge for the neighborhood",
+          active: true,
+          pair_preferred: false
+        }
+        |> Map.merge(attrs)
+      )
+      |> Repo.insert()
+
+    fridge
+    |> Repo.preload(:location)
+  end
+
   def fixture(:sms_message_from_rider, rider),
     do: fixture(:sms_message_from_rider, rider, %{})
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -186,38 +186,6 @@ defmodule BikeBrigade.Fixtures do
     Toronto.random_location()
   end
 
-  def fixture(:community_fridge, attrs) do
-    # Ensure we have a location_id
-    attrs =
-      attrs
-      |> Map.put_new_lazy(:location_id, fn ->
-        location_data = fixture(:location)
-
-        {:ok, location} =
-          %BikeBrigade.Locations.Location{}
-          |> BikeBrigade.Locations.Location.changeset(location_data)
-          |> Repo.insert()
-
-        location.id
-      end)
-
-    {:ok, fridge} =
-      %BikeBrigade.Locations.CommunityFridge{}
-      |> BikeBrigade.Locations.CommunityFridge.changeset(
-        %{
-          name: "Community Fridge #{System.unique_integer([:positive])}",
-          description: "A community fridge for the neighborhood",
-          active: true,
-          pair_preferred: false
-        }
-        |> Map.merge(attrs)
-      )
-      |> Repo.insert()
-
-    fridge
-    |> Repo.preload(:location)
-  end
-
   def fixture(:sms_message_from_rider, rider),
     do: fixture(:sms_message_from_rider, rider, %{})
 


### PR DESCRIPTION
## Describe your changes

 - Create CommunityFridge schema with name, description, photo, active status, and pair_preferred fields
  - Associate community fridges with locations via foreign key
  - Update Location schema to include has_one relationship to community fridges
  - Add migration: create_community_fridges


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for recording community fridge locations with names and descriptive details.
  - Added active-status and pairing-preference settings.
  - Community fridges are linked to specific locations, with safeguards against duplicate location assignments.
  - Location records now display their associated community fridge information.

- **Bug Fixes**
  - Added validation to ensure every community fridge has a name and valid location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->