### PR TITLE
Fix backup riders being auto-assigned tasks in campaigns

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -649,6 +649,7 @@ defmodule BikeBrigade.Delivery do
         ],
         left_join: t in Task,
         on: t.assigned_rider_id == r.id and t.campaign_id == ^campaign.id,
+        where: cr.backup_rider == false,
         preload: [:location, assigned_tasks: {t, :task_items}],
         select: {r, cr.rider_capacity}
 


### PR DESCRIPTION

## Describe your changes

This PR fixes a bug where backup riders were incorrectly receiving automatic task assignments in the campaign auto-assign flow, and as a side effect, caused campaigns to display as "filled" on the Delivery Signup page even when
open rides remained available.

closes #511 
## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic task assignments now exclude riders designated as backups, preventing them from being selected as primary riders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->