### PR TITLE
Fix backup riders' task assignments resolving to nil (#513)

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -551,8 +551,18 @@ defmodule BikeBrigade.Delivery do
       )
       |> Repo.preload([:location, :total_stats])
 
-    # Does a nested preload to get tasks' assigned riders without doing an extra db query
-    tasks = Repo.preload(all_tasks, assigned_rider: fn _ -> all_riders end)
+    # Fetches all riders for this campaign regardless of backup status, used only
+    # to correctly resolve task.assigned_rider in the preload below. Backup riders
+    # are excluded from all_riders (display) but their task assignments must still resolve.
+    all_riders_for_resolution =
+      Repo.all(
+        from cr in CampaignRider,
+          join: r in assoc(cr, :rider),
+          where: cr.campaign_id == ^campaign.id,
+          select: r
+      )
+
+    tasks = Repo.preload(all_tasks, assigned_rider: fn _ -> all_riders_for_resolution end)
 
     riders = Repo.preload(all_riders, assigned_tasks: fn _ -> all_tasks end)
 


### PR DESCRIPTION
 ## Describe your changes

When a rider marked themselves as backup, their existing task assignments silently appeared unclaimed on the signup page. The root cause: campaign_riders_and_tasks/1 was reusing all_riders — filtered to backup_rider == false — for the in-memory preload that resolves task.assigned_rider. Backup riders were absent from that list, so the preload resolved their assigned_rider_id to nil despite the database being correct.

  Split into two queries: all_riders stays filtered for the display panel, and a new all_riders_for_resolution — unfiltered, no logistics fields — is used solely for the preload. Backup riders no longer vanish from assignment resolution without affecting what the riders panel shows.
<!-- Please add a link to a ticket if relevant: eg: "closes #340" -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task assignments so riders designated as backups are now correctly displayed when viewing campaign tasks.
  * Preserved the existing display behavior that excludes backup riders from the general rider list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->