### PR TITLE
Allow backup riders to take specific deliveries

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -406,45 +406,12 @@ defmodule BikeBrigade.Delivery do
   end
 
   def create_campaign_rider(attrs \\ %{}) do
-    # Check if rider is already signed up as backup rider for this campaign
-    campaign_id = attrs["campaign_id"] || attrs[:campaign_id]
-    rider_id = attrs["rider_id"] || attrs[:rider_id]
-
-    case {campaign_id, rider_id} do
-      {nil, _} ->
-        create_campaign_rider_without_backup_check(attrs)
-
-      {_, nil} ->
-        create_campaign_rider_without_backup_check(attrs)
-
-      {campaign_id, rider_id} ->
-        case Repo.get_by(CampaignRider,
-               campaign_id: campaign_id,
-               rider_id: rider_id,
-               backup_rider: true
-             ) do
-          nil ->
-            # No backup rider exists, proceed with normal signup
-            create_campaign_rider_without_backup_check(attrs)
-
-          _backup_rider ->
-            # Backup rider exists, prevent regular signup
-            changeset =
-              %CampaignRider{}
-              |> CampaignRider.changeset(attrs)
-              |> Ecto.Changeset.add_error(:rider_id, "already signed up as backup rider")
-
-            {:error, changeset}
-        end
-    end
-  end
-
-  def create_campaign_rider_without_backup_check(attrs) do
     %CampaignRider{}
     |> CampaignRider.changeset(attrs)
     |> Repo.insert(
       on_conflict: {:replace, [:rider_capacity, :notes, :pickup_window, :enter_building]},
-      conflict_target: [:rider_id, :campaign_id]
+      conflict_target: [:rider_id, :campaign_id],
+      returning: true
     )
     |> broadcast(:campaign_rider_created)
   end
@@ -532,12 +499,23 @@ defmodule BikeBrigade.Delivery do
       |> Repo.all()
       |> Repo.preload([:pickup_location, dropoff_location: [:neighborhood], task_items: [:item]])
 
+    # Backup-only riders stay out of the regular rider roster. Riders who are both
+    # backups and assigned deliveries stay in it so their task assignments resolve
+    # in the in-memory preload below.
+    assigned_rider_ids =
+      all_tasks
+      |> Enum.map(& &1.assigned_rider_id)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
     all_riders =
       Repo.all(
         from cr in CampaignRider,
           join: r in assoc(cr, :rider),
           left_join: l in assoc(r, :location),
-          where: cr.campaign_id == ^campaign.id and cr.backup_rider == false,
+          where:
+            cr.campaign_id == ^campaign.id and
+              (cr.backup_rider == false or r.id in ^assigned_rider_ids),
           order_by: r.name,
           select: r,
           select_merge: %{
@@ -560,6 +538,13 @@ defmodule BikeBrigade.Delivery do
   end
 
   def get_backup_riders(%Campaign{} = campaign) do
+    assigned_tasks =
+      Repo.all(
+        from t in Task,
+          where: t.campaign_id == ^campaign.id and not is_nil(t.assigned_rider_id),
+          order_by: t.id
+      )
+
     backup_riders =
       Repo.all(
         from cr in CampaignRider,
@@ -575,7 +560,7 @@ defmodule BikeBrigade.Delivery do
             delivery_url_token: cr.token
           }
       )
-      |> Repo.preload([:total_stats])
+      |> Repo.preload([:total_stats, assigned_tasks: fn _ -> assigned_tasks end])
 
     backup_riders
   end
@@ -603,8 +588,12 @@ defmodule BikeBrigade.Delivery do
         {:error, :not_found}
 
       campaign_rider ->
-        Repo.delete(campaign_rider)
-        |> broadcast(:campaign_rider_deleted)
+        if rider_assigned_to_campaign?(campaign, rider_id) do
+          update_campaign_rider(campaign_rider, %{backup_rider: false})
+        else
+          Repo.delete(campaign_rider)
+          |> broadcast(:campaign_rider_deleted)
+        end
     end
   end
 
@@ -835,7 +824,9 @@ defmodule BikeBrigade.Delivery do
 
   def remove_rider_from_campaign(campaign, rider_id) do
     if cr = Repo.get_by(CampaignRider, campaign_id: campaign.id, rider_id: rider_id) do
-      delete_campaign_rider(cr)
+      if !cr.backup_rider do
+        delete_campaign_rider(cr)
+      end
     end
 
     tasks =
@@ -847,6 +838,13 @@ defmodule BikeBrigade.Delivery do
     for task <- tasks do
       update_task(task, %{assigned_rider_id: nil})
     end
+  end
+
+  defp rider_assigned_to_campaign?(campaign, rider_id) do
+    Repo.exists?(
+      from t in Task,
+        where: t.campaign_id == ^campaign.id and t.assigned_rider_id == ^rider_id
+    )
   end
 
   alias BikeBrigade.Delivery.Program

--- a/lib/bike_brigade_web/live/campaign_live/riders_list_component.ex
+++ b/lib/bike_brigade_web/live/campaign_live/riders_list_component.ex
@@ -13,4 +13,8 @@ defmodule BikeBrigadeWeb.CampaignLive.RidersListComponent do
      |> assign(assigns)
      |> assign(:riders_list, filter_riders(riders, riders_query))}
   end
+
+  defp backup_rider?(backup_riders, rider) do
+    is_map(backup_riders) && Map.has_key?(backup_riders, rider.id)
+  end
 end

--- a/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
@@ -60,6 +60,12 @@
               <span class="text-xs">
                 ({task_count(rider.assigned_tasks)} / {rider.task_capacity})
               </span>
+              <span
+                :if={backup_rider?(@backup_riders, rider)}
+                class="inline-flex items-center px-2 py-0.5 ml-1 text-xs font-semibold text-green-800 bg-green-100 rounded-full"
+              >
+                Available as backup
+              </span>
             </div>
             <%= if rider.task_enter_building do %>
               <Heroicons.building_office
@@ -112,6 +118,13 @@
                 </div>
               </div>
             <% end %>
+            <div
+              :if={backup_rider?(@backup_riders, rider)}
+              class="flex items-center px-2 py-2 my-2 text-sm font-medium text-green-800 border border-green-200 rounded bg-green-50"
+            >
+              <Heroicons.check_circle mini class="flex-shrink-0 w-4 h-4 mr-2" />
+              Also available as a backup rider
+            </div>
             <%= if Enum.count(rider.assigned_tasks) > 0 do %>
               <%= for task <- rider.assigned_tasks do %>
                 <div class="flex flex-row my-2">
@@ -173,26 +186,41 @@
   </ul>
   
 <!-- Backup Riders Section -->
-  <div :if={@backup_riders && Enum.count(@backup_riders) > 0} class="border-t mt-4 pt-4">
+  <div :if={@backup_riders && Enum.count(@backup_riders) > 0} class="pt-4 mt-4 border-t">
     <div class="ml-2 mb-2">
-      <h3 class="text-sm font-medium leading-6 text-gray-900 ml-2">
+      <h3 class="ml-2 text-sm font-medium leading-6 text-gray-900">
         Backup Riders ({Enum.count(@backup_riders)})
       </h3>
+      <p class="mx-2 text-xs leading-4 text-gray-600">
+        Available if extra coverage is needed.
+      </p>
     </div>
 
     <ul class="overflow-y-auto scrolling-touch" id="backup-riders-list">
       <%= for {_id, rider} <- @backup_riders do %>
-        <li id={"backup-riders-list:#{rider.id}"}>
+        <li id={"backup-riders-list:#{rider.id}"} class="my-1 border-l-4 border-green-400">
           <.link
             phx-click={JS.push("select_backup_rider", value: %{id: rider.id})}
             class={
-              "block transition duration-150 ease-in-out hover:bg-gray-50 focus:outline-none focus:bg-gray-50#{if selected?(@selected_rider, rider), do: " bg-gray-100"}"
+              "block transition duration-150 ease-in-out bg-green-50 hover:bg-green-100 focus:outline-none focus:bg-green-100#{if selected?(@selected_rider, rider), do: " bg-green-100"}"
             }
           >
             <div class="flex flex-row items-center px-4 py-4">
               <div class="text-sm font-medium">
                 {rider.name}
-                <span class="text-xs text-blue-600">(backup)</span>
+                <span class="inline-flex items-center px-2 py-0.5 ml-1 text-xs font-semibold text-green-800 bg-green-100 rounded-full">
+                  Available as backup
+                </span>
+                <span
+                  :if={Enum.any?(rider.assigned_tasks)}
+                  class="block mt-1 text-xs text-gray-600"
+                >
+                  {Enum.count(rider.assigned_tasks)} specific {ngettext(
+                    "delivery",
+                    "deliveries",
+                    Enum.count(rider.assigned_tasks)
+                  )} assigned
+                </span>
               </div>
 
               <%= if rider.task_enter_building do %>
@@ -249,20 +277,21 @@
                 </div>
               <% end %>
 
-              <div class="mx-1 text-sm leading-5 text-gray-800">
-                Signed up as backup rider - no specific tasks assigned
+              <div class="px-2 py-2 mx-1 text-sm font-medium leading-5 text-green-800 border border-green-200 rounded bg-green-50">
+                <%= if Enum.any?(rider.assigned_tasks) do %>
+                  Available as backup while assigned to {Enum.count(rider.assigned_tasks)} specific {ngettext(
+                    "delivery",
+                    "deliveries",
+                    Enum.count(rider.assigned_tasks)
+                  )}.
+                <% else %>
+                  Available as backup — no specific tasks assigned.
+                <% end %>
               </div>
 
               <div class="flex flex-row mt-5 space-x-1">
                 <.button navigate={~p"/messages/#{rider}"} color={:secondary} size={:xsmall}>
                   Message
-                </.button>
-                <.button
-                  phx-click={JS.push("convert_backup_to_rider", value: %{rider_id: rider.id})}
-                  color={:green}
-                  size={:xsmall}
-                >
-                  Convert to Rider
                 </.button>
               </div>
               <div class="mt-1">
@@ -271,7 +300,11 @@
                   color={:red}
                   size={:xsmall}
                 >
-                  Remove Backup
+                  <%= if Enum.any?(rider.assigned_tasks) do %>
+                    Stop Backup Availability
+                  <% else %>
+                    Remove Backup
+                  <% end %>
                 </.button>
               </div>
             </div>

--- a/lib/bike_brigade_web/live/campaign_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_live/show.ex
@@ -331,34 +331,6 @@ defmodule BikeBrigadeWeb.CampaignLive.Show do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("convert_backup_to_rider", %{"rider_id" => rider_id}, socket) do
-    backup_rider = get_backup_rider(socket, rider_id)
-
-    # Remove the backup rider record
-    Delivery.remove_backup_rider_from_campaign(socket.assigns.campaign, backup_rider.id)
-
-    # Create a new regular campaign rider record
-    attrs = %{
-      "campaign_id" => socket.assigns.campaign.id,
-      "rider_id" => backup_rider.id,
-      "rider_capacity" => backup_rider.task_capacity || 1,
-      "pickup_window" => backup_rider.pickup_window,
-      "enter_building" => backup_rider.task_enter_building,
-      "rider_signed_up" => true
-    }
-
-    case Delivery.create_campaign_rider_without_backup_check(attrs) do
-      {:ok, _cr} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Successfully converted #{backup_rider.name} to a regular rider")}
-
-      {:error, _changeset} ->
-        {:noreply, socket |> put_flash(:error, "Failed to convert backup rider to regular rider")}
-    end
-  end
-
-  @impl Phoenix.LiveView
   def handle_event("remove_backup_rider", %{"rider_id" => rider_id}, socket) do
     backup_rider = get_backup_rider(socket, rider_id)
     Delivery.remove_backup_rider_from_campaign(socket.assigns.campaign, backup_rider.id)

--- a/lib/bike_brigade_web/live/campaign_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/show.html.heex
@@ -110,7 +110,6 @@
         tasks_query={@tasks_query}
         selected_task={@selected_task}
         selected_rider={@selected_rider}
-        backup_riders={@backup_riders}
       />
     </div>
     <div class="px-2 py-3 bg-white shadow min-h-96 max-h-128 md:min-h-0 md:max-h-full md:h-full md:order-last sm:rounded-lg">

--- a/lib/bike_brigade_web/live/campaign_live/tasks_list_component.ex
+++ b/lib/bike_brigade_web/live/campaign_live/tasks_list_component.ex
@@ -31,12 +31,4 @@ defmodule BikeBrigadeWeb.CampaignLive.TasksListComponent do
 
     {:noreply, socket}
   end
-
-  defp is_backup_rider?(backup_riders, selected_rider) do
-    case backup_riders do
-      nil -> false
-      riders when is_map(riders) -> Map.has_key?(riders, selected_rider.id)
-      _ -> false
-    end
-  end
 end

--- a/lib/bike_brigade_web/live/campaign_live/tasks_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/tasks_list_component.html.heex
@@ -133,7 +133,7 @@
                   >
                     Unassign
                   </.button>
-                <% @selected_rider != nil && !is_backup_rider?(@backup_riders, @selected_rider) -> %>
+                <% @selected_rider != nil -> %>
                   <div class="mx-1 text-sm leading-5">
                     <.button
                       phx-click={
@@ -146,10 +146,6 @@
                     >
                       Assign to {@selected_rider.name}
                     </.button>
-                  </div>
-                <% @selected_rider != nil && is_backup_rider?(@backup_riders, @selected_rider) -> %>
-                  <div class="mx-1 text-sm leading-5 text-gray-500 italic">
-                    {@selected_rider.name} is a backup rider - cannot assign tasks
                   </div>
                 <% true -> %>
                   <div class="mx-1 text-sm leading-5 text-gray-500">None</div>

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -113,15 +113,6 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     {:noreply, socket}
   end
 
-  def handle_event("backup_rider_tried_signing_up", _, socket) do
-    {:noreply,
-     socket
-     |> put_flash(
-       :error,
-       "You are currently signed up as a backup rider. If you wish to sign up for this task, cancel being a backup rider below."
-     )}
-  end
-
   def handle_event("signup_rider", %{"rider_id" => rider_id, "task_id" => task_id}, socket) do
     %{campaign: campaign, tasks: tasks} = socket.assigns
     task = Enum.find(tasks, fn task -> task.id == task_id end)
@@ -190,6 +181,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     :task_deleted,
     :task_updated,
     :campaign_rider_created,
+    :campaign_rider_updated,
     :campaign_rider_deleted
   ]
 
@@ -294,7 +286,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
         </.button>
       <% end %>
 
-      <%= if task_eligible_for_signup?(@task, @campaign, @backup_riders, @current_rider_id) do %>
+      <%= if task_eligible_for_signup?(@task, @campaign) do %>
         <.button
           phx-click={
             JS.push("signup_rider", value: %{task_id: @task.id, rider_id: @current_rider_id})
@@ -304,19 +296,6 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
           size={:xsmall}
           class="w-full md:w-28"
           replace
-        >
-          Sign up
-        </.button>
-      <% end %>
-
-      <%= if backup_rider_signed_up?(@backup_riders, @current_rider_id) && 
-              task_available_but_backup_rider?(@task, @campaign) do %>
-        <.button
-          phx-click={JS.push("backup_rider_tried_signing_up")}
-          color={:secondary}
-          id={"#{@id}-backup-rider-#{@task.id}"}
-          size={:xsmall}
-          class="w-full md:w-28 bg-neutral-100 cursor-not-allowed text-neutral-800"
         >
           Sign up
         </.button>
@@ -336,15 +315,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     """
   end
 
-  defp task_eligible_for_signup?(task, campaign, backup_riders, current_rider_id) do
-    # campaign not in past, task available, and rider is not a backup rider
-    task.assigned_rider == nil &&
-      !campaign_in_past(campaign) &&
-      !backup_rider_signed_up?(backup_riders, current_rider_id)
-  end
-
-  defp task_available_but_backup_rider?(task, campaign) do
-    # task is available but user is backup rider
+  defp task_eligible_for_signup?(task, campaign) do
     task.assigned_rider == nil && !campaign_in_past(campaign)
   end
 

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -252,7 +252,7 @@ defmodule BikeBrigade.DeliveryTest do
       assert hd(riders).id == regular_rider.id
     end
 
-    test "backup riders cannot sign up for regular tasks via signup_rider event", %{
+    test "a backup rider can also sign up for a task", %{
       campaign: campaign,
       backup_rider: backup_rider
     } do
@@ -267,10 +267,8 @@ defmodule BikeBrigade.DeliveryTest do
           "rider_signed_up" => true
         })
 
-      # Create a task
-      fixture(:task, %{campaign: campaign})
+      task = fixture(:task, %{campaign: campaign})
 
-      # Try to create a regular campaign rider for the backup rider (this should fail)
       attrs = %{
         "campaign_id" => campaign.id,
         "rider_id" => backup_rider.id,
@@ -280,41 +278,87 @@ defmodule BikeBrigade.DeliveryTest do
         "rider_signed_up" => true
       }
 
-      # This should fail since backup rider already exists
-      assert {:error, changeset} = Delivery.create_campaign_rider(attrs)
-      assert {"already signed up as backup rider", []} = changeset.errors[:rider_id]
+      assert {:ok, campaign_rider} = Delivery.create_campaign_rider(attrs)
+      assert campaign_rider.backup_rider
+
+      user = fixture(:user)
+      assert {:ok, _task} = Delivery.assign_task(task, backup_rider.id, user.id)
+
+      {riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
+      assert Enum.any?(riders, &(&1.id == backup_rider.id))
+      assert Enum.any?(Delivery.get_backup_riders(campaign), &(&1.id == backup_rider.id))
+
+      assigned_task = Enum.find(tasks, &(&1.id == task.id))
+      assert assigned_task.assigned_rider.id == backup_rider.id
     end
 
-    test "create_campaign_rider_without_backup_check/1 allows conversion of backup riders", %{
+    test "signing up as backup preserves an existing task assignment", %{
       campaign: campaign,
-      backup_rider: backup_rider
+      rider: rider
     } do
-      # Create a backup campaign rider
+      task = fixture(:task, %{campaign: campaign, rider: rider})
+
       {:ok, _backup_cr} =
         Delivery.create_backup_campaign_rider(%{
           "campaign_id" => campaign.id,
-          "rider_id" => backup_rider.id,
-          "rider_capacity" => "3",
+          "rider_id" => rider.id,
+          "rider_capacity" => "1",
           "pickup_window" => "10:00-11:00AM",
           "enter_building" => true,
           "rider_signed_up" => true
         })
 
-      # Should be able to create regular campaign rider even though backup exists
-      # (this simulates the conversion process)
-      attrs = %{
-        "campaign_id" => campaign.id,
-        "rider_id" => backup_rider.id,
-        "rider_capacity" => "3",
-        "pickup_window" => "10:00-11:00AM",
-        "enter_building" => true,
-        "rider_signed_up" => true
-      }
+      {riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
+      assert Enum.any?(riders, &(&1.id == rider.id))
+      assert Enum.any?(Delivery.get_backup_riders(campaign), &(&1.id == rider.id))
 
-      assert {:ok, regular_cr} = Delivery.create_campaign_rider_without_backup_check(attrs)
-      assert regular_cr.backup_rider == false
-      assert regular_cr.rider_id == backup_rider.id
-      assert regular_cr.rider_capacity == 3
+      assigned_task = Enum.find(tasks, &(&1.id == task.id))
+      assert assigned_task.assigned_rider.id == rider.id
+    end
+
+    test "cancelling backup status preserves task signup", %{campaign: campaign, rider: rider} do
+      task = fixture(:task, %{campaign: campaign, rider: rider})
+
+      {:ok, _backup_cr} =
+        Delivery.create_backup_campaign_rider(%{
+          "campaign_id" => campaign.id,
+          "rider_id" => rider.id,
+          "rider_capacity" => "1",
+          "pickup_window" => "10:00-11:00AM",
+          "enter_building" => true,
+          "rider_signed_up" => true
+        })
+
+      assert {:ok, campaign_rider} =
+               Delivery.remove_backup_rider_from_campaign(campaign, rider.id)
+
+      refute campaign_rider.backup_rider
+      assert Delivery.get_task(task.id).assigned_rider_id == rider.id
+      assert Delivery.get_backup_riders(campaign) == []
+    end
+
+    test "removing the final task signup preserves backup status", %{
+      campaign: campaign,
+      backup_rider: rider
+    } do
+      task = fixture(:task, %{campaign: campaign})
+
+      {:ok, _backup_cr} =
+        Delivery.create_backup_campaign_rider(%{
+          "campaign_id" => campaign.id,
+          "rider_id" => rider.id,
+          "rider_capacity" => "1",
+          "pickup_window" => "10:00-11:00AM",
+          "enter_building" => true,
+          "rider_signed_up" => true
+        })
+
+      user = fixture(:user)
+      {:ok, _task} = Delivery.assign_task(task, rider.id, user.id)
+      Delivery.remove_rider_from_campaign(campaign, rider.id)
+
+      assert Delivery.get_task(task.id).assigned_rider_id == nil
+      assert Enum.any?(Delivery.get_backup_riders(campaign), &(&1.id == rider.id))
     end
   end
 

--- a/test/bike_brigade_web/live/campaign_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_live_test.exs
@@ -272,12 +272,56 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
           "rider_signed_up" => true
         })
 
-      {:ok, _view, html} = live(ctx.conn, ~p"/campaigns/#{ctx.campaign}")
+      {:ok, view, html} = live(ctx.conn, ~p"/campaigns/#{ctx.campaign}")
 
       # Check backup riders section is present
       assert html =~ "Backup Riders (1)"
       assert html =~ rider.name
-      assert html =~ "(backup)"
+      assert html =~ "Available as backup"
+
+      view |> element("#backup-riders-list a", rider.name) |> render_click()
+      assert render(view) =~ "Available as backup — no specific tasks assigned."
+    end
+
+    test "highlights riders who have assignments and are also available as backup", ctx do
+      rider = fixture(:rider)
+      task = fixture(:task, %{campaign: ctx.campaign, assigned_rider_id: rider.id})
+
+      {:ok, _backup_cr} =
+        Delivery.create_backup_campaign_rider(%{
+          "campaign_id" => ctx.campaign.id,
+          "rider_id" => rider.id,
+          "rider_capacity" => "5",
+          "pickup_window" => "10:00-11:00AM",
+          "enter_building" => true,
+          "rider_signed_up" => true
+        })
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/campaigns/#{ctx.campaign}")
+
+      assert has_element?(
+               view,
+               "#riders-list\\:#{rider.id}",
+               "Available as backup"
+             )
+
+      assert has_element?(
+               view,
+               "#backup-riders-list\\:#{rider.id}",
+               "1 specific delivery assigned"
+             )
+
+      view |> element("#backup-riders-list\\:#{rider.id} a", rider.name) |> render_click()
+
+      assert render(view) =~ "Available as backup while assigned to 1 specific delivery."
+      assert render(view) =~ task.dropoff_name
+      assert has_element?(view, "a", "Stop Backup Availability")
+      refute has_element?(view, "a", "Convert to Rider")
+
+      view |> element("a", "Stop Backup Availability") |> render_click()
+
+      assert Delivery.get_task(task.id).assigned_rider_id == rider.id
+      refute Enum.any?(Delivery.get_backup_riders(ctx.campaign), &(&1.id == rider.id))
     end
 
     test "can select a backup rider", ctx do
@@ -297,35 +341,8 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
       {:ok, view, _html} = live(ctx.conn, ~p"/campaigns/#{ctx.campaign}")
 
       view |> element("#backup-riders-list a", rider.name) |> render_click()
-      assert view |> element("a", "Convert to Rider") |> has_element?()
-    end
-
-    test "can convert backup rider to regular rider", ctx do
-      rider = fixture(:rider)
-
-      # Create a backup rider
-      {:ok, _backup_cr} =
-        Delivery.create_backup_campaign_rider(%{
-          "campaign_id" => ctx.campaign.id,
-          "rider_id" => rider.id,
-          "rider_capacity" => "5",
-          "pickup_window" => "10:00-11:00AM",
-          "enter_building" => true,
-          "rider_signed_up" => true
-        })
-
-      {:ok, view, _html} = live(ctx.conn, ~p"/campaigns/#{ctx.campaign}")
-
-      # First click on backup rider to select them
-      updated_html = view |> element("#backup-riders-list a", rider.name) |> render_click()
-
-      # check that backup rider details are showing
-      assert updated_html =~ "Convert to Rider"
-
-      # Now convert should be available
-      view |> element("a", "Convert to Rider") |> render_click()
-      # after converting to a rider, confirm the button no longer exists.
-      refute view |> element("a", "Convert to Rider") |> has_element?
+      assert view |> element("a", "Remove Backup") |> has_element?()
+      refute view |> element("a", "Convert to Rider") |> has_element?()
     end
 
     test "can remove backup rider", ctx do
@@ -355,7 +372,7 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
       refute render(view) =~ rider.name
     end
 
-    test "cannot assign tasks to backup riders", ctx do
+    test "can assign tasks to backup riders", ctx do
       rider = fixture(:rider)
       task = fixture(:task, %{campaign: ctx.campaign})
 
@@ -378,10 +395,15 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
       # Select the backup rider
       view |> element("#backup-riders-list a", rider.name) |> render_click()
 
-      # Should show message that backup rider cannot be assigned tasks
       task_html = view |> element("[id='tasks-list:#{task.id}']") |> render()
-      assert task_html =~ "#{rider.name} is a backup rider - cannot assign tasks"
-      refute task_html =~ "Assign to #{rider.name}"
+      assert task_html =~ "Assign to #{rider.name}"
+
+      view
+      |> element("[id='tasks-list:#{task.id}'] a", "Assign to #{rider.name}")
+      |> render_click()
+
+      assert Delivery.get_task(task.id).assigned_rider_id == rider.id
+      assert Enum.any?(Delivery.get_backup_riders(ctx.campaign), &(&1.id == rider.id))
     end
 
     test "can message backup riders", ctx do

--- a/test/bike_brigade_web/live/campaign_signup_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_signup_live_test.exs
@@ -309,7 +309,7 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       assert log.user_id == ctx.user.id
     end
 
-    test "Backup rider cannot sign up for regular tasks", ctx do
+    test "Backup rider can sign up for regular tasks", ctx do
       # First sign up as backup rider
       {:ok, _backup_cr} =
         Delivery.create_backup_campaign_rider(%{
@@ -323,13 +323,11 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
 
       {:ok, live, _html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
 
-      # Click the button and get the updated HTML
-      live |> element("#signup-btn-desktop-backup-rider-#{ctx.task.id}") |> render_click()
-      updated_html = render(live)
+      live |> element("#signup-btn-desktop-sign-up-task-#{ctx.task.id}") |> render_click()
 
-      # Check that the flash message appears
-      assert updated_html =~
-               "You are currently signed up as a backup rider. If you wish to sign up for this task, cancel being a backup rider below."
+      assert render(live) =~ "You"
+      assert Delivery.get_task(ctx.task.id).assigned_rider_id == ctx.rider.id
+      assert Enum.any?(Delivery.get_backup_riders(ctx.campaign), &(&1.id == ctx.rider.id))
     end
   end
 
@@ -448,18 +446,36 @@ defmodule BikeBrigadeWeb.CampaignSignupLiveTest do
       assert html =~ "No backup riders signed up yet."
     end
 
-    test "regular rider cannot sign up for tasks when they are backup rider", ctx do
+    test "task signup and backup signup can coexist", ctx do
       # Sign up as backup rider
       {:ok, live, _html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
       live |> element("#signup-backup-rider-btn") |> render_click()
 
-      # Try to sign up for a task - should show flash message
-      live |> element("#signup-btn-desktop-backup-rider-#{ctx.task.id}") |> render_click()
+      live |> element("#signup-btn-desktop-sign-up-task-#{ctx.task.id}") |> render_click()
       updated_html = render(live)
 
-      # Should show the flash message
-      assert updated_html =~
-               "You are currently signed up as a backup rider. If you wish to sign up for this task, cancel being a backup rider below."
+      assert updated_html =~ "You"
+      assert updated_html =~ "Cancel backup signup"
+      assert Delivery.get_task(ctx.task.id).assigned_rider_id == ctx.rider.id
+      assert Enum.any?(Delivery.get_backup_riders(ctx.campaign), &(&1.id == ctx.rider.id))
+    end
+
+    test "task assignment survives signing up as backup and cancelling backup", ctx do
+      {:ok, live, _html} = live(ctx.conn, ~p"/campaigns/signup/#{ctx.campaign.id}/")
+
+      live |> element("#signup-btn-desktop-sign-up-task-#{ctx.task.id}") |> render_click()
+      live |> element("#signup-backup-rider-btn") |> render_click()
+
+      assert render(live) =~ "You"
+      assert has_element?(live, "#cancel-backup-rider-btn")
+      assert Delivery.get_task(ctx.task.id).assigned_rider_id == ctx.rider.id
+
+      live |> element("#cancel-backup-rider-btn") |> render_click()
+
+      assert render(live) =~ "You"
+      assert has_element?(live, "#signup-backup-rider-btn")
+      assert Delivery.get_task(ctx.task.id).assigned_rider_id == ctx.rider.id
+      assert Delivery.get_backup_riders(ctx.campaign) == []
     end
   end
 


### PR DESCRIPTION
Treat backup availability and task assignment as independent states. Preserve assignments when backup status changes, allow dispatchers and riders to assign deliveries to backup riders, and clarify dual-role riders in the campaign UI.

Closes #513

<img width="1924" height="816" alt="CleanShot 2026-09-04 at 10 50 29@2x" src="https://github.com/user-attachments/assets/687a6ab8-46e9-4a9e-9210-260ec00613d0" />
<img width="1878" height="738" alt="CleanShot 2026-09-04 at 10 50 02@2x" src="https://github.com/user-attachments/assets/8d2b34cb-ac24-4f0d-89f5-69b6f9cca4d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup riders can now sign up for regular deliveries and be assigned tasks without losing backup availability.
  * Campaign rosters show backup riders with assigned delivery details and availability indicators.
  * Backup status and regular task assignments can be managed independently.

* **Bug Fixes**
  * Removing backup availability preserves assigned deliveries and converts the rider to a regular campaign rider when applicable.
  * Backup riders without assigned deliveries can be removed cleanly.

* **UI Updates**
  * Updated labels and status messages clarify backup availability and assigned deliveries.
  * Removed the “Convert to Rider” control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->