### PR TITLE
 Fix campaign list panels resizing with expanded items

### DIFF
--- a/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/riders_list_component.html.heex
@@ -1,5 +1,5 @@
-<div class="flex flex-col max-h-full">
-  <div class="flex flex-col flex-wrap items-baseline flex-grow space-y-1 xl:flex-row xl:space-x-1">
+<div class="flex flex-col h-full min-h-0">
+  <div class="flex flex-col flex-wrap items-baseline shrink-0 space-y-1 xl:flex-row xl:space-x-1">
     <.button phx-click="auto_assign" size={:small} class="space-x-1">
       <p>Auto Assign</p>
       <.with_tooltip>
@@ -45,163 +45,29 @@
       placeholder="Search Riders"
     />
   </div>
-  <ul class="flex-1 overflow-y-auto scrolling-touch" id="riders-list" phx-hook="RidersList">
-    <%= for {_id, rider} <- @riders_list do %>
-      <li id={"riders-list:#{rider.id}"}>
-        <.link
-          phx-click={JS.push("select_rider", value: %{id: rider.id})}
-          class={
+  <div class="flex-1 min-h-0 overflow-y-auto scrolling-touch">
+    <ul id="riders-list" phx-hook="RidersList">
+      <%= for {_id, rider} <- @riders_list do %>
+        <li id={"riders-list:#{rider.id}"}>
+          <.link
+            phx-click={JS.push("select_rider", value: %{id: rider.id})}
+            class={
             "block transition duration-150 ease-in-out hover:bg-gray-50 focus:outline-none focus:bg-gray-50#{if selected?(@selected_rider, rider), do: " bg-gray-100"}"
           }
-        >
-          <div class="flex flex-row items-center px-4 py-4">
-            <div class="text-sm font-medium">
-              {rider.name}
-              <span class="text-xs">
-                ({task_count(rider.assigned_tasks)} / {rider.task_capacity})
-              </span>
-            </div>
-            <%= if rider.task_enter_building do %>
-              <Heroicons.building_office
-                mini
-                class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500 justify-self-end"
-              />
-            <% end %>
-            <%= if novice_participant?(rider) do %>
-              <.with_tooltip>
-                <Heroicons.star
-                  mini
-                  class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500 justify-self-end"
-                />
-                <:tooltip>
-                  <div class="w-18">
-                    New rider (less than 5 campaigns)
-                  </div>
-                </:tooltip>
-              </.with_tooltip>
-            <% end %>
-
-            <%= if has_notes?(rider) do %>
-              <Heroicons.pencil_square mini class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500" />
-            <% end %>
-            <%= if rider.text_based_itinerary do %>
-              <.with_tooltip>
-                <Heroicons.signal_slash mini class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500" />
-                <:tooltip>
-                  <div class="w-40">
-                    This rider will receive an extra message with text-only delivery instructions
-                  </div>
-                </:tooltip>
-              </.with_tooltip>
-            <% end %>
-          </div>
-        </.link>
-        <%= if selected?(@selected_rider, rider) do %>
-          <div class="p-2 mx-1 rounded-b shadow-inner bg-gray-50">
-            <div class="flex flex-row my-2">
-              <Heroicons.clock mini class="flex-shrink-0 w-4 h-4 text-gray-500" />
-              <div class="mx-1 text-sm leading-5 text-gray-800">
-                {pickup_window(@campaign, rider)}
-              </div>
-            </div>
-            <%= if has_notes?(rider) do %>
-              <div class="flex flex-row my-2">
-                <Heroicons.pencil_square mini class="flex-shrink-0 w-4 h-4 text-gray-500" />
-                <div class="mx-1 text-sm leading-5 text-gray-600">
-                  {rider.task_notes}
-                </div>
-              </div>
-            <% end %>
-            <%= if Enum.count(rider.assigned_tasks) > 0 do %>
-              <%= for task <- rider.assigned_tasks do %>
-                <div class="flex flex-row my-2">
-                  <Heroicons.map_pin mini class="flex-shrink-0 w-4 h-4 text-gray-500" />
-                  <.link
-                    phx-click={JS.push("select_task", value: %{id: task.id})}
-                    class="flex flex-col"
-                  >
-                    <div class="mx-1 text-sm leading-5 text-indigo-600">
-                      <span class="pii">{task.dropoff_location}</span>
-                    </div>
-                    <div class="mx-1 text-xs font-medium leading-5">
-                      <span class="pii">{task.dropoff_name}</span>
-                    </div>
-                  </.link>
-                </div>
-              <% end %>
-            <% else %>
-              <div class="mx-1 text-sm leading-5 text-gray-800">No tasks</div>
-            <% end %>
-            <div class="flex flex-row mt-5 space-x-1">
-              <%= if @resent do %>
-                <.button
-                  phx-click={JS.push("resend_message", value: %{rider_id: rider.id})}
-                  size={:xsmall}
-                  disabled
-                >
-                  Sent!
-                </.button>
-              <% else %>
-                <.button
-                  phx-click={JS.push("resend_message", value: %{rider_id: rider.id})}
-                  size={:xsmall}
-                >
-                  Resend
-                </.button>
-              <% end %>
-              <.button navigate={~p"/messages/#{rider}"} color={:secondary} size={:xsmall}>
-                Message
-              </.button>
-
-              <.button patch={~p"/campaigns/#{@campaign}/edit_rider/#{rider}"} size={:xsmall}>
-                Edit Rider
-              </.button>
-            </div>
-            <div class="mt-1">
-              <.button
-                phx-click={JS.push("remove_rider", value: %{rider_id: rider.id})}
-                color={:red}
-                size={:xsmall}
-              >
-                Remove
-              </.button>
-            </div>
-          </div>
-        <% end %>
-      </li>
-    <% end %>
-  </ul>
-  
-<!-- Backup Riders Section -->
-  <div :if={@backup_riders && Enum.count(@backup_riders) > 0} class="border-t mt-4 pt-4">
-    <div class="ml-2 mb-2">
-      <h3 class="text-sm font-medium leading-6 text-gray-900 ml-2">
-        Backup Riders ({Enum.count(@backup_riders)})
-      </h3>
-    </div>
-
-    <ul class="overflow-y-auto scrolling-touch" id="backup-riders-list">
-      <%= for {_id, rider} <- @backup_riders do %>
-        <li id={"backup-riders-list:#{rider.id}"}>
-          <.link
-            phx-click={JS.push("select_backup_rider", value: %{id: rider.id})}
-            class={
-              "block transition duration-150 ease-in-out hover:bg-gray-50 focus:outline-none focus:bg-gray-50#{if selected?(@selected_rider, rider), do: " bg-gray-100"}"
-            }
           >
             <div class="flex flex-row items-center px-4 py-4">
               <div class="text-sm font-medium">
                 {rider.name}
-                <span class="text-xs text-blue-600">(backup)</span>
+                <span class="text-xs">
+                  ({task_count(rider.assigned_tasks)} / {rider.task_capacity})
+                </span>
               </div>
-
               <%= if rider.task_enter_building do %>
                 <Heroicons.building_office
                   mini
                   class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500 justify-self-end"
                 />
               <% end %>
-
               <%= if novice_participant?(rider) do %>
                 <.with_tooltip>
                   <Heroicons.star
@@ -219,7 +85,6 @@
               <%= if has_notes?(rider) do %>
                 <Heroicons.pencil_square mini class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500" />
               <% end %>
-
               <%= if rider.text_based_itinerary do %>
                 <.with_tooltip>
                   <Heroicons.signal_slash mini class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500" />
@@ -233,7 +98,7 @@
             </div>
           </.link>
           <%= if selected?(@selected_rider, rider) do %>
-            <div class="p-2 mx-1 rounded-b shadow-inner bg-blue-50">
+            <div class="p-2 mx-1 rounded-b shadow-inner bg-gray-50">
               <div class="flex flex-row my-2">
                 <Heroicons.clock mini class="flex-shrink-0 w-4 h-4 text-gray-500" />
                 <div class="mx-1 text-sm leading-5 text-gray-800">
@@ -248,30 +113,58 @@
                   </div>
                 </div>
               <% end %>
-
-              <div class="mx-1 text-sm leading-5 text-gray-800">
-                Signed up as backup rider - no specific tasks assigned
-              </div>
-
+              <%= if Enum.count(rider.assigned_tasks) > 0 do %>
+                <%= for task <- rider.assigned_tasks do %>
+                  <div class="flex flex-row my-2">
+                    <Heroicons.map_pin mini class="flex-shrink-0 w-4 h-4 text-gray-500" />
+                    <.link
+                      phx-click={JS.push("select_task", value: %{id: task.id})}
+                      class="flex flex-col"
+                    >
+                      <div class="mx-1 text-sm leading-5 text-indigo-600">
+                        <span class="pii">{task.dropoff_location}</span>
+                      </div>
+                      <div class="mx-1 text-xs font-medium leading-5">
+                        <span class="pii">{task.dropoff_name}</span>
+                      </div>
+                    </.link>
+                  </div>
+                <% end %>
+              <% else %>
+                <div class="mx-1 text-sm leading-5 text-gray-800">No tasks</div>
+              <% end %>
               <div class="flex flex-row mt-5 space-x-1">
+                <%= if @resent do %>
+                  <.button
+                    phx-click={JS.push("resend_message", value: %{rider_id: rider.id})}
+                    size={:xsmall}
+                    disabled
+                  >
+                    Sent!
+                  </.button>
+                <% else %>
+                  <.button
+                    phx-click={JS.push("resend_message", value: %{rider_id: rider.id})}
+                    size={:xsmall}
+                  >
+                    Resend
+                  </.button>
+                <% end %>
                 <.button navigate={~p"/messages/#{rider}"} color={:secondary} size={:xsmall}>
                   Message
                 </.button>
-                <.button
-                  phx-click={JS.push("convert_backup_to_rider", value: %{rider_id: rider.id})}
-                  color={:green}
-                  size={:xsmall}
-                >
-                  Convert to Rider
+
+                <.button patch={~p"/campaigns/#{@campaign}/edit_rider/#{rider}"} size={:xsmall}>
+                  Edit Rider
                 </.button>
               </div>
               <div class="mt-1">
                 <.button
-                  phx-click={JS.push("remove_backup_rider", value: %{rider_id: rider.id})}
+                  phx-click={JS.push("remove_rider", value: %{rider_id: rider.id})}
                   color={:red}
                   size={:xsmall}
                 >
-                  Remove Backup
+                  Remove
                 </.button>
               </div>
             </div>
@@ -279,5 +172,113 @@
         </li>
       <% end %>
     </ul>
+
+    <div :if={@backup_riders && Enum.count(@backup_riders) > 0} class="pt-4 mt-4 border-t">
+      <div class="mb-2 ml-2">
+        <h3 class="ml-2 text-sm font-medium leading-6 text-gray-900">
+          Backup Riders ({Enum.count(@backup_riders)})
+        </h3>
+      </div>
+
+      <ul id="backup-riders-list">
+        <%= for {_id, rider} <- @backup_riders do %>
+          <li id={"backup-riders-list:#{rider.id}"}>
+            <.link
+              phx-click={JS.push("select_backup_rider", value: %{id: rider.id})}
+              class={
+              "block transition duration-150 ease-in-out hover:bg-gray-50 focus:outline-none focus:bg-gray-50#{if selected?(@selected_rider, rider), do: " bg-gray-100"}"
+            }
+            >
+              <div class="flex flex-row items-center px-4 py-4">
+                <div class="text-sm font-medium">
+                  {rider.name}
+                  <span class="text-xs text-blue-600">(backup)</span>
+                </div>
+
+                <%= if rider.task_enter_building do %>
+                  <Heroicons.building_office
+                    mini
+                    class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500 justify-self-end"
+                  />
+                <% end %>
+
+                <%= if novice_participant?(rider) do %>
+                  <.with_tooltip>
+                    <Heroicons.star
+                      mini
+                      class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500 justify-self-end"
+                    />
+                    <:tooltip>
+                      <div class="w-18">
+                        New rider (less than 5 campaigns)
+                      </div>
+                    </:tooltip>
+                  </.with_tooltip>
+                <% end %>
+
+                <%= if has_notes?(rider) do %>
+                  <Heroicons.pencil_square mini class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500" />
+                <% end %>
+
+                <%= if rider.text_based_itinerary do %>
+                  <.with_tooltip>
+                    <Heroicons.signal_slash mini class="flex-shrink-0 w-4 h-4 mx-1 text-gray-500" />
+                    <:tooltip>
+                      <div class="w-40">
+                        This rider will receive an extra message with text-only delivery instructions
+                      </div>
+                    </:tooltip>
+                  </.with_tooltip>
+                <% end %>
+              </div>
+            </.link>
+            <%= if selected?(@selected_rider, rider) do %>
+              <div class="p-2 mx-1 rounded-b shadow-inner bg-blue-50">
+                <div class="flex flex-row my-2">
+                  <Heroicons.clock mini class="flex-shrink-0 w-4 h-4 text-gray-500" />
+                  <div class="mx-1 text-sm leading-5 text-gray-800">
+                    {pickup_window(@campaign, rider)}
+                  </div>
+                </div>
+                <%= if has_notes?(rider) do %>
+                  <div class="flex flex-row my-2">
+                    <Heroicons.pencil_square mini class="flex-shrink-0 w-4 h-4 text-gray-500" />
+                    <div class="mx-1 text-sm leading-5 text-gray-600">
+                      {rider.task_notes}
+                    </div>
+                  </div>
+                <% end %>
+
+                <div class="mx-1 text-sm leading-5 text-gray-800">
+                  Signed up as backup rider - no specific tasks assigned
+                </div>
+
+                <div class="flex flex-row mt-5 space-x-1">
+                  <.button navigate={~p"/messages/#{rider}"} color={:secondary} size={:xsmall}>
+                    Message
+                  </.button>
+                  <.button
+                    phx-click={JS.push("convert_backup_to_rider", value: %{rider_id: rider.id})}
+                    color={:green}
+                    size={:xsmall}
+                  >
+                    Convert to Rider
+                  </.button>
+                </div>
+                <div class="mt-1">
+                  <.button
+                    phx-click={JS.push("remove_backup_rider", value: %{rider_id: rider.id})}
+                    color={:red}
+                    size={:xsmall}
+                  >
+                    Remove Backup
+                  </.button>
+                </div>
+              </div>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 </div>

--- a/lib/bike_brigade_web/live/campaign_live/show.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/show.html.heex
@@ -1,4 +1,4 @@
-<div class="flex flex-col h-full">
+<div class="flex flex-col md:h-[calc(100vh-3rem)]">
   <div class="flex flex-row flex-wrap items-center md:flex-nowrap">
     <.button patch={~p"/campaigns/#{@campaign}/messaging"} class="mr-3">
       <Heroicons.chat_bubble_left_right mini class="w-5 h-5 mr-2 -ml-1" /> Messaging
@@ -100,8 +100,8 @@
       </div>
     </div>
   </div>
-  <div class="grid min-h-0 grid-cols-2 gap-4 md:h-full md:grid-cols-4">
-    <div class="px-2 py-3 bg-white shadow min-h-96 max-h-128 md:min-h-0 md:max-h-full x-2 md:h-full sm:rounded-lg">
+  <div class="grid flex-1 min-h-0 grid-cols-2 gap-4 md:grid-cols-4">
+    <div class="h-96 px-2 py-3 overflow-hidden bg-white shadow md:h-full md:min-h-0 sm:rounded-lg">
       <.live_component
         module={TasksListComponent}
         id={:tasks_list}
@@ -113,7 +113,7 @@
         backup_riders={@backup_riders}
       />
     </div>
-    <div class="px-2 py-3 bg-white shadow min-h-96 max-h-128 md:min-h-0 md:max-h-full md:h-full md:order-last sm:rounded-lg">
+    <div class="h-96 px-2 py-3 overflow-hidden bg-white shadow md:h-full md:min-h-0 md:order-last sm:rounded-lg">
       <.live_component
         module={RidersListComponent}
         id={:riders_list}
@@ -126,8 +126,8 @@
         resent={@resent}
       />
     </div>
-    <div class="col-span-2 bg-white shadow min-h-96 max-h-128 md:min-h-0 md:max-h-full sm:rounded-lg">
-      <div class="px-4 py-5 h-96 md:h-full sm:p-6">
+    <div class="h-96 col-span-2 overflow-hidden bg-white shadow md:h-full md:min-h-0 sm:rounded-lg">
+      <div class="h-full px-4 py-5 sm:p-6">
         <.campaign_map campaign={@campaign} riders={@riders} tasks={@tasks} />
       </div>
     </div>

--- a/lib/bike_brigade_web/live/campaign_live/tasks_list_component.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/tasks_list_component.html.heex
@@ -1,5 +1,5 @@
-<div class="flex flex-col max-h-full">
-  <div class="flex flex-row flex-wrap items-baseline flex-grow space-y-1">
+<div class="flex flex-col h-full min-h-0">
+  <div class="flex flex-row flex-wrap items-baseline shrink-0 space-y-1">
     <.button patch={~p"/campaigns/#{@campaign}/tasks/new"} size={:small}>
       Add Task
     </.button>
@@ -42,7 +42,11 @@
       placeholder="Search Deliveries"
     />
   </div>
-  <ul class="flex-1 pt-10 overflow-y-auto scrolling-touch" id="tasks-list" phx-hook="TasksList">
+  <ul
+    class="flex-1 min-h-0 pt-10 overflow-y-auto scrolling-touch"
+    id="tasks-list"
+    phx-hook="TasksList"
+  >
     <%= for {_id, task} <- @tasks_list do %>
       <li id={"tasks-list:#{task.id}"}>
         <.link


### PR DESCRIPTION
Constrain the campaign workspace to the available viewport height and scroll task and rider content within their panels so the map and columns remain consistently sized.
From 
<img width="1912" height="1204" alt="CleanShot 2026-09-04 at 12 52 11@2x" src="https://github.com/user-attachments/assets/711f119a-ea6c-4866-98c0-db0482820e16" />
to
<img width="1868" height="1608" alt="CleanShot 2026-09-04 at 12 52 24@2x" src="https://github.com/user-attachments/assets/7d6dfbdd-f3d4-42a9-a213-46df95f8bd13" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved campaign page scrolling and panel sizing across screen sizes.
  * Consolidated rider list scrolling to provide smoother navigation through main and backup riders.
  * Adjusted task, rider, and map panels to maintain consistent visibility within the campaign layout.

* **Style**
  * Updated the selected rider details panel background for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->