### PR TITLE
Fix flaky campaign deletion test with escaped names

### DIFF
--- a/test/bike_brigade_web/live/campaign_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_live_test.exs
@@ -2,7 +2,6 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
   use BikeBrigadeWeb.ConnCase, only: []
 
   import Phoenix.LiveViewTest
-  alias BikeBrigadeWeb.CampaignHelpers
 
   alias BikeBrigade.{Delivery, LocalizedDateTime, History}
 
@@ -56,10 +55,12 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
     end
 
     test "Can delete a campaign", ctx do
-      {:ok, view, html} = live(ctx.conn, ~p"/campaigns/")
-      assert html =~ CampaignHelpers.name(ctx.campaign)
-      html = view |> element("#campaign-#{ctx.campaign.id} a", "Delete") |> render_click()
-      refute html =~ CampaignHelpers.name(ctx.campaign)
+      {:ok, view, _html} = live(ctx.conn, ~p"/campaigns/")
+      assert has_element?(view, "#campaign-#{ctx.campaign.id}")
+
+      view |> element("#campaign-#{ctx.campaign.id} a", "Delete") |> render_click()
+
+      refute has_element?(view, "#campaign-#{ctx.campaign.id}")
     end
   end
 


### PR DESCRIPTION
## Describe your changes

<!-- Please add a link to a ticket if relevant: eg: "closes #340" -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [x] Are there other PRs or Issues that I should link to here?
- [ ] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated campaign deletion coverage to verify that the campaign is no longer displayed after deletion.
  - Simplified assertions by checking the campaign element directly instead of inspecting rendered HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->