### PR TITLE
Enforce rider assignment consistency

### DIFF
--- a/lib/bike_brigade/delivery.ex
+++ b/lib/bike_brigade/delivery.ex
@@ -161,18 +161,43 @@ defmodule BikeBrigade.Delivery do
 
   def assign_task(%Task{} = task, rider_id, user_id, opts \\ []) when is_list(opts) do
     Repo.transaction(fn ->
-      {:ok, _log} =
-        History.create_task_assignment_log(%{
-          task_id: task.id,
-          rider_id: rider_id,
-          user_id: user_id,
-          action: :assigned
-        })
+      lock_campaign!(task.campaign_id)
+      task = lock_task!(task.id)
+      ensure_campaign_rider!(task.campaign_id, rider_id)
+      do_assign_task(task, rider_id, user_id)
+    end)
+  end
 
-      {:ok, task} =
-        update_task(task, %{assigned_rider_id: rider_id}, opts)
+  @doc """
+  Atomically adds a rider to a campaign and claims an unassigned task.
+  """
+  def claim_task(%Task{} = task, campaign_rider_attrs, user_id)
+      when is_map(campaign_rider_attrs) do
+    Repo.transaction(fn ->
+      lock_campaign!(task.campaign_id)
 
-      task
+      campaign_rider =
+        case create_campaign_rider(campaign_rider_attrs) do
+          {:ok, campaign_rider} -> campaign_rider
+          {:error, reason} -> Repo.rollback(reason)
+        end
+
+      if campaign_rider.campaign_id != task.campaign_id do
+        Repo.rollback(:campaign_mismatch)
+      end
+
+      rider_id = campaign_rider.rider_id
+
+      case lock_task!(task.id) do
+        %Task{assigned_rider_id: nil} = task ->
+          do_assign_task(task, rider_id, user_id)
+
+        %Task{assigned_rider_id: ^rider_id} = task ->
+          task
+
+        %Task{} ->
+          Repo.rollback(:already_assigned)
+      end
     end)
   end
 
@@ -183,18 +208,85 @@ defmodule BikeBrigade.Delivery do
   def unassign_task(%Task{assigned_rider_id: assigned_rider_id} = task, user_id, opts \\ [])
       when not is_nil(assigned_rider_id) and is_list(opts) do
     Repo.transaction(fn ->
-      {:ok, _log} =
-        History.create_task_assignment_log(%{
-          task_id: task.id,
-          rider_id: assigned_rider_id,
-          user_id: user_id,
-          action: :unassigned
-        })
+      lock_campaign!(task.campaign_id)
 
-      {:ok, task} = update_task(task, %{assigned_rider_id: nil}, opts)
+      case lock_task!(task.id) do
+        %Task{assigned_rider_id: ^assigned_rider_id} = task ->
+          do_unassign_task(task, assigned_rider_id, user_id)
+
+        %Task{assigned_rider_id: nil} ->
+          Repo.rollback(:not_assigned)
+
+        %Task{} ->
+          Repo.rollback(:assignment_changed)
+      end
+    end)
+  end
+
+  @doc """
+  Unassigns a rider's task and removes their regular campaign membership when
+  they have no assignments left. Backup membership is preserved.
+  """
+  def cancel_task_signup(%Task{} = task, rider_id, user_id) do
+    Repo.transaction(fn ->
+      lock_campaign!(task.campaign_id)
+
+      task =
+        case lock_task!(task.id) do
+          %Task{assigned_rider_id: ^rider_id} = task ->
+            do_unassign_task(task, rider_id, user_id)
+
+          %Task{assigned_rider_id: nil} = task ->
+            task
+
+          %Task{} ->
+            Repo.rollback(:assignment_changed)
+        end
+
+      unless rider_assigned_to_campaign?(task.campaign_id, rider_id) do
+        delete_regular_campaign_rider(task.campaign_id, rider_id)
+      end
 
       task
     end)
+  end
+
+  defp do_assign_task(task, rider_id, user_id) do
+    with {:ok, _log} <-
+           History.create_task_assignment_log(%{
+             task_id: task.id,
+             rider_id: rider_id,
+             user_id: user_id,
+             action: :assigned
+           }),
+         {:ok, task} <-
+           task
+           |> Task.assignment_changeset(%{assigned_rider_id: rider_id})
+           |> Repo.update()
+           |> broadcast(:task_updated) do
+      task
+    else
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
+  defp do_unassign_task(task, rider_id, user_id) do
+    with {:ok, _log} <-
+           History.create_task_assignment_log(%{
+             task_id: task.id,
+             rider_id: rider_id,
+             user_id: user_id,
+             action: :unassigned
+           }),
+         {:ok, task} <-
+           task
+           |> Task.assignment_changeset(%{assigned_rider_id: nil})
+           |> Repo.update()
+           |> broadcast(:task_updated) do
+      task
+    else
+      {:error, reason} -> Repo.rollback(reason)
+    end
   end
 
   @doc """
@@ -579,22 +671,39 @@ defmodule BikeBrigade.Delivery do
   end
 
   def remove_backup_rider_from_campaign(%Campaign{} = campaign, rider_id) do
-    case Repo.get_by(CampaignRider,
-           campaign_id: campaign.id,
-           rider_id: rider_id,
-           backup_rider: true
-         ) do
-      nil ->
-        {:error, :not_found}
+    Repo.transaction(fn ->
+      lock_campaign!(campaign.id)
 
-      campaign_rider ->
-        if rider_assigned_to_campaign?(campaign, rider_id) do
-          update_campaign_rider(campaign_rider, %{backup_rider: false})
-        else
-          Repo.delete(campaign_rider)
-          |> broadcast(:campaign_rider_deleted)
-        end
-    end
+      case Repo.get_by(CampaignRider,
+             campaign_id: campaign.id,
+             rider_id: rider_id,
+             backup_rider: true
+           ) do
+        nil ->
+          Repo.rollback(:not_found)
+
+        campaign_rider ->
+          result =
+            if rider_assigned_to_campaign?(campaign, rider_id) do
+              update_campaign_rider(campaign_rider, %{backup_rider: false})
+            else
+              Repo.delete(campaign_rider)
+              |> broadcast(:campaign_rider_deleted)
+            end
+
+          case result do
+            {:ok, campaign_rider} -> campaign_rider
+            {:error, reason} -> Repo.rollback(reason)
+          end
+      end
+    end)
+  end
+
+  defp lock_campaign!(campaign_id) do
+    from(c in Campaign, where: c.id == ^campaign_id, select: c.id, lock: "FOR UPDATE")
+    |> Repo.one!()
+
+    :ok
   end
 
   # TODO RENAME TO TODAYS TASKS
@@ -626,7 +735,14 @@ defmodule BikeBrigade.Delivery do
     Repo.one(query)
   end
 
-  def hacky_assign(%Campaign{} = campaign) do
+  def hacky_assign(%Campaign{} = campaign, user_id) do
+    Repo.transaction(fn ->
+      lock_campaign!(campaign.id)
+      do_hacky_assign(campaign, user_id)
+    end)
+  end
+
+  defp do_hacky_assign(campaign, user_id) do
     riders_query =
       from r in Rider,
         join: cr in CampaignRider,
@@ -674,7 +790,7 @@ defmodule BikeBrigade.Delivery do
         Logger.info("Assigning #{Enum.count(to_assign)} items to #{rider.name}")
 
         for task <- to_assign do
-          update_task(task, %{assigned_rider_id: rider.id})
+          do_assign_task(task, rider.id, user_id)
         end
       end
     end
@@ -822,29 +938,63 @@ defmodule BikeBrigade.Delivery do
     end
   end
 
-  def remove_rider_from_campaign(campaign, rider_id) do
-    if cr = Repo.get_by(CampaignRider, campaign_id: campaign.id, rider_id: rider_id) do
-      if !cr.backup_rider do
-        delete_campaign_rider(cr)
-      end
-    end
+  @doc """
+  Atomically unassigns a rider's campaign tasks and removes regular membership.
+  Backup membership is preserved.
+  """
+  def remove_rider_from_campaign(%Campaign{} = campaign, rider_id, user_id) do
+    Repo.transaction(fn ->
+      lock_campaign!(campaign.id)
 
-    tasks =
-      from(t in Task,
-        where: t.campaign_id == ^campaign.id and t.assigned_rider_id == ^rider_id
-      )
-      |> Repo.all()
+      tasks =
+        from(t in Task,
+          where: t.campaign_id == ^campaign.id and t.assigned_rider_id == ^rider_id,
+          lock: "FOR UPDATE"
+        )
+        |> Repo.all()
 
-    for task <- tasks do
-      update_task(task, %{assigned_rider_id: nil})
+      tasks = Enum.map(tasks, &do_unassign_task(&1, rider_id, user_id))
+      delete_regular_campaign_rider(campaign.id, rider_id)
+      tasks
+    end)
+  end
+
+  defp delete_regular_campaign_rider(campaign_id, rider_id) do
+    case Repo.get_by(CampaignRider, campaign_id: campaign_id, rider_id: rider_id) do
+      %CampaignRider{backup_rider: false} = campaign_rider ->
+        case delete_campaign_rider(campaign_rider) do
+          {:ok, _campaign_rider} -> :ok
+          {:error, reason} -> Repo.rollback(reason)
+        end
+
+      _ ->
+        :ok
     end
   end
 
-  defp rider_assigned_to_campaign?(campaign, rider_id) do
+  defp rider_assigned_to_campaign?(%{id: campaign_id}, rider_id) do
+    rider_assigned_to_campaign?(campaign_id, rider_id)
+  end
+
+  defp rider_assigned_to_campaign?(campaign_id, rider_id) do
     Repo.exists?(
       from t in Task,
-        where: t.campaign_id == ^campaign.id and t.assigned_rider_id == ^rider_id
+        where: t.campaign_id == ^campaign_id and t.assigned_rider_id == ^rider_id
     )
+  end
+
+  defp ensure_campaign_rider!(campaign_id, rider_id) do
+    unless Repo.exists?(
+             from cr in CampaignRider,
+               where: cr.campaign_id == ^campaign_id and cr.rider_id == ^rider_id
+           ) do
+      Repo.rollback(:rider_not_in_campaign)
+    end
+  end
+
+  defp lock_task!(task_id) do
+    from(t in Task, where: t.id == ^task_id, lock: "FOR UPDATE")
+    |> Repo.one!()
   end
 
   alias BikeBrigade.Delivery.Program

--- a/lib/bike_brigade/delivery/task.ex
+++ b/lib/bike_brigade/delivery/task.ex
@@ -25,7 +25,6 @@ defmodule BikeBrigade.Delivery.Task do
     :partner_tracking_id,
     :delivery_instructions,
     :signup_notes,
-    :assigned_rider_id,
     :campaign_id
   ]
 
@@ -89,6 +88,13 @@ defmodule BikeBrigade.Delivery.Task do
     ])
     |> assoc_constraint(:dropoff_location)
     |> cast_assoc(:task_items)
+  end
+
+  def assignment_changeset(task, attrs) do
+    task
+    |> cast(attrs, [:assigned_rider_id])
+    |> foreign_key_constraint(:assigned_rider_id)
+    |> foreign_key_constraint(:assigned_rider_id, name: :tasks_campaign_rider_fkey)
   end
 
   def fields_for(task) do

--- a/lib/bike_brigade_web/live/campaign_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_live/show.ex
@@ -179,7 +179,10 @@ defmodule BikeBrigadeWeb.CampaignLive.Show do
 
   @impl true
   def handle_event("auto_assign", _, socket) do
-    BikeBrigade.Delivery.hacky_assign(socket.assigns.campaign)
+    BikeBrigade.Delivery.hacky_assign(
+      socket.assigns.campaign,
+      socket.assigns.current_user.id
+    )
 
     {:noreply, socket}
   end
@@ -253,9 +256,12 @@ defmodule BikeBrigadeWeb.CampaignLive.Show do
 
   @impl true
   def handle_event("assign_task", %{"task_id" => task_id, "rider_id" => rider_id}, socket) do
-    {:ok, _task} =
-      get_task(socket, task_id)
-      |> Delivery.assign_task(rider_id, socket.assigns.current_user.id)
+    socket =
+      case get_task(socket, task_id)
+           |> Delivery.assign_task(rider_id, socket.assigns.current_user.id) do
+        {:ok, _task} -> socket
+        {:error, _reason} -> put_flash(socket, :error, "Unable to assign this delivery.")
+      end
 
     {:noreply, socket}
   end
@@ -264,11 +270,15 @@ defmodule BikeBrigadeWeb.CampaignLive.Show do
   def handle_event("unassign_task", %{"task_id" => task_id}, socket) do
     task = get_task(socket, task_id)
 
-    if task.assigned_rider do
-      {:ok, _task} =
-        task
-        |> Delivery.unassign_task(socket.assigns.current_user.id)
-    end
+    socket =
+      if task.assigned_rider do
+        case Delivery.unassign_task(task, socket.assigns.current_user.id) do
+          {:ok, _task} -> socket
+          {:error, _reason} -> put_flash(socket, :error, "Unable to unassign this delivery.")
+        end
+      else
+        socket
+      end
 
     {:noreply, socket}
   end
@@ -304,7 +314,11 @@ defmodule BikeBrigadeWeb.CampaignLive.Show do
   def handle_event("remove_rider", %{"rider_id" => rider_id}, socket) do
     rider = get_rider(socket, rider_id)
 
-    Delivery.remove_rider_from_campaign(socket.assigns.campaign, rider.id)
+    Delivery.remove_rider_from_campaign(
+      socket.assigns.campaign,
+      rider.id,
+      socket.assigns.current_user.id
+    )
 
     {:noreply, socket}
   end

--- a/lib/bike_brigade_web/live/campaign_signup_live/show.ex
+++ b/lib/bike_brigade_web/live/campaign_signup_live/show.ex
@@ -91,24 +91,15 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
     task = get_task(socket, task_id)
     rider_id = socket.assigns.current_user.rider_id
 
-    if task.assigned_rider do
-      {:ok, _task} =
-        task
-        |> Delivery.unassign_task(socket.assigns.current_user.id)
-    end
-
-    # If rider is no longer assigned to any tasks, remove them from the campaign
-    rider_has_no_other_tasks? =
-      socket.assigns.tasks
-      # remove the task that was just clicked
-      |> Enum.reject(fn t -> t.id === task_id end)
-      # if the rider's is not found in any other of the tasks, return true.
-      |> Enum.filter(fn t -> t.assigned_rider_id == rider_id end)
-      |> Enum.empty?()
-
-    if rider_has_no_other_tasks? do
-      Delivery.remove_rider_from_campaign(socket.assigns.campaign, rider_id)
-    end
+    socket =
+      if task.assigned_rider do
+        case Delivery.cancel_task_signup(task, rider_id, socket.assigns.current_user.id) do
+          {:ok, _task} -> socket
+          {:error, _reason} -> put_flash(socket, :error, "That assignment has changed.")
+        end
+      else
+        socket
+      end
 
     {:noreply, socket}
   end
@@ -128,13 +119,21 @@ defmodule BikeBrigadeWeb.CampaignSignupLive.Show do
       "rider_signed_up" => true
     }
 
-    case Delivery.create_campaign_rider(attrs) do
-      {:ok, _cr} ->
-        {:ok, _task} = Delivery.assign_task(task, rider_id, socket.assigns.current_user.id)
+    case Delivery.claim_task(task, attrs, socket.assigns.current_user.id) do
+      {:ok, _task} ->
         {:noreply, socket |> push_patch(to: ~p"/campaigns/signup/#{campaign}", replace: true)}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, :changeset, changeset)}
+
+      {:error, :already_assigned} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "This delivery was just claimed by another rider.")
+         |> push_patch(to: ~p"/campaigns/signup/#{campaign}", replace: true)}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, "Unable to claim this delivery.")}
     end
   end
 

--- a/priv/repo/migrations/20260904000001_enforce_task_campaign_rider_assignment.exs
+++ b/priv/repo/migrations/20260904000001_enforce_task_campaign_rider_assignment.exs
@@ -1,0 +1,50 @@
+defmodule BikeBrigade.Repo.Migrations.EnforceTaskCampaignRiderAssignment do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    INSERT INTO campaigns_riders (
+      campaign_id,
+      rider_id,
+      rider_capacity,
+      enter_building,
+      token,
+      rider_signed_up,
+      backup_rider,
+      inserted_at,
+      updated_at
+    )
+    SELECT DISTINCT
+      tasks.campaign_id,
+      tasks.assigned_rider_id,
+      1,
+      FALSE,
+      md5(
+        'campaign-rider-assignment-backfill:' ||
+        tasks.campaign_id::text || ':' || tasks.assigned_rider_id::text
+      ),
+      FALSE,
+      FALSE,
+      NOW(),
+      NOW()
+    FROM tasks
+    LEFT JOIN campaigns_riders
+      ON campaigns_riders.campaign_id = tasks.campaign_id
+      AND campaigns_riders.rider_id = tasks.assigned_rider_id
+    WHERE tasks.campaign_id IS NOT NULL
+      AND tasks.assigned_rider_id IS NOT NULL
+      AND campaigns_riders.id IS NULL
+    """)
+
+    execute("""
+    ALTER TABLE tasks
+    ADD CONSTRAINT tasks_campaign_rider_fkey
+    FOREIGN KEY (campaign_id, assigned_rider_id)
+    REFERENCES campaigns_riders (campaign_id, rider_id)
+    """)
+  end
+
+  def down do
+    execute("ALTER TABLE tasks DROP CONSTRAINT tasks_campaign_rider_fkey")
+  end
+end

--- a/test/bike_brigade/delivery_test.exs
+++ b/test/bike_brigade/delivery_test.exs
@@ -70,6 +70,9 @@ defmodule BikeBrigade.DeliveryTest do
     user = fixture(:user)
     task = fixture(:task, %{campaign: campaign})
 
+    {:ok, _campaign_rider} =
+      Delivery.create_campaign_rider(%{campaign_id: campaign.id, rider_id: rider.id})
+
     assert {:ok, task} = Delivery.assign_task(task, rider.id, user.id)
 
     assert task.assigned_rider_id == rider.id
@@ -79,6 +82,84 @@ defmodule BikeBrigade.DeliveryTest do
     assert log.rider_id == rider.id
     assert log.user_id == user.id
     assert log.action == :assigned
+  end
+
+  test "assign_task/3 rejects a rider who is not in the campaign" do
+    campaign = fixture(:campaign)
+    rider = fixture(:rider)
+    user = fixture(:user)
+    task = fixture(:task, %{campaign: campaign})
+
+    assert {:error, :rider_not_in_campaign} =
+             Delivery.assign_task(task, rider.id, user.id)
+
+    assert Delivery.get_task(task.id).assigned_rider_id == nil
+    assert History.list_task_assignment_logs() == []
+  end
+
+  test "claim_task/3 creates campaign membership and assigns an unclaimed task" do
+    campaign = fixture(:campaign)
+    rider = fixture(:rider)
+    user = fixture(:user)
+    task = fixture(:task, %{campaign: campaign})
+
+    attrs = %{
+      campaign_id: campaign.id,
+      rider_id: rider.id,
+      rider_capacity: 1,
+      enter_building: true
+    }
+
+    assert {:ok, %Task{assigned_rider_id: rider_id}} =
+             Delivery.claim_task(task, attrs, user.id)
+
+    assert rider_id == rider.id
+    assert Repo.get_by(Delivery.CampaignRider, campaign_id: campaign.id, rider_id: rider.id)
+  end
+
+  test "claim_task/3 does not replace another rider's assignment" do
+    campaign = fixture(:campaign)
+    assigned_rider = fixture(:rider)
+    claiming_rider = fixture(:rider)
+    user = fixture(:user)
+    task = fixture(:task, %{campaign: campaign, rider: assigned_rider})
+
+    attrs = %{
+      campaign_id: campaign.id,
+      rider_id: claiming_rider.id,
+      rider_capacity: 1,
+      enter_building: true
+    }
+
+    assert {:error, :already_assigned} = Delivery.claim_task(task, attrs, user.id)
+    assert Delivery.get_task(task.id).assigned_rider_id == assigned_rider.id
+
+    refute Repo.get_by(Delivery.CampaignRider,
+             campaign_id: campaign.id,
+             rider_id: claiming_rider.id
+           )
+  end
+
+  test "the general task changeset cannot change rider assignment" do
+    task = fixture(:task)
+    rider = fixture(:rider)
+
+    changeset = Task.changeset(task, %{assigned_rider_id: rider.id})
+
+    refute Map.has_key?(changeset.changes, :assigned_rider_id)
+  end
+
+  test "the database rejects an assigned rider outside the campaign" do
+    campaign = fixture(:campaign)
+    rider = fixture(:rider)
+    task = fixture(:task, %{campaign: campaign})
+
+    assert {:error, changeset} =
+             task
+             |> Task.assignment_changeset(%{assigned_rider_id: rider.id})
+             |> Repo.update()
+
+    assert "does not exist" in errors_on(changeset).assigned_rider_id
   end
 
   test "unassign_task/3" do
@@ -96,6 +177,29 @@ defmodule BikeBrigade.DeliveryTest do
     assert log.rider_id == rider.id
     assert log.user_id == user.id
     assert log.action == :unassigned
+  end
+
+  test "hacky_assign/2 uses the assignment boundary and records history" do
+    campaign = fixture(:campaign)
+    rider = fixture(:rider)
+    user = fixture(:user)
+    task = fixture(:task, %{campaign: campaign})
+
+    {:ok, _campaign_rider} =
+      Delivery.create_campaign_rider(%{
+        campaign_id: campaign.id,
+        rider_id: rider.id,
+        rider_capacity: 1
+      })
+
+    assert {:ok, _assignments} = Delivery.hacky_assign(campaign, user.id)
+    assert Delivery.get_task(task.id).assigned_rider_id == rider.id
+
+    assert [log] = History.list_task_assignment_logs()
+    assert log.task_id == task.id
+    assert log.rider_id == rider.id
+    assert log.user_id == user.id
+    assert log.action == :assigned
   end
 
   describe "Backup Riders" do
@@ -337,6 +441,70 @@ defmodule BikeBrigade.DeliveryTest do
       assert Delivery.get_backup_riders(campaign) == []
     end
 
+    test "concurrent task assignment prevents backup rider deletion", %{
+      campaign: campaign,
+      backup_rider: rider
+    } do
+      task = fixture(:task, %{campaign: campaign})
+      user = fixture(:user)
+
+      {:ok, _backup_rider} =
+        Delivery.create_backup_campaign_rider(%{
+          "campaign_id" => campaign.id,
+          "rider_id" => rider.id,
+          "rider_capacity" => "1",
+          "pickup_window" => "10:00-11:00AM",
+          "enter_building" => true,
+          "rider_signed_up" => true
+        })
+
+      test_pid = self()
+      handler_id = "pause-after-campaign-lock-#{System.unique_integer()}"
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          [:bike_brigade, :repo, :query],
+          fn _event, _measurements, metadata, test_pid ->
+            if String.contains?(metadata.query, ~s(FOR UPDATE)) do
+              send(test_pid, {:campaign_locked, self()})
+
+              receive do
+                :continue -> :ok
+              after
+                1_000 -> :ok
+              end
+            end
+          end,
+          test_pid
+        )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assignment = Elixir.Task.async(fn -> Delivery.assign_task(task, rider.id, user.id) end)
+      assert_receive {:campaign_locked, assignment_pid}
+      :ok = :telemetry.detach(handler_id)
+
+      removal =
+        Elixir.Task.async(fn ->
+          Delivery.remove_backup_rider_from_campaign(campaign, rider.id)
+        end)
+
+      refute Elixir.Task.yield(removal, 50)
+      send(assignment_pid, :continue)
+
+      assert {:ok, %Task{assigned_rider_id: rider_id}} = Elixir.Task.await(assignment)
+      assert rider_id == rider.id
+      assert {:ok, campaign_rider} = Elixir.Task.await(removal)
+      refute campaign_rider.backup_rider
+
+      {riders, tasks} = Delivery.campaign_riders_and_tasks(campaign)
+      assert Enum.any?(riders, &(&1.id == rider.id))
+
+      assigned_task = Enum.find(tasks, &(&1.id == task.id))
+      assert assigned_task.assigned_rider.id == rider.id
+    end
+
     test "removing the final task signup preserves backup status", %{
       campaign: campaign,
       backup_rider: rider
@@ -355,7 +523,7 @@ defmodule BikeBrigade.DeliveryTest do
 
       user = fixture(:user)
       {:ok, _task} = Delivery.assign_task(task, rider.id, user.id)
-      Delivery.remove_rider_from_campaign(campaign, rider.id)
+      Delivery.remove_rider_from_campaign(campaign, rider.id, user.id)
 
       assert Delivery.get_task(task.id).assigned_rider_id == nil
       assert Enum.any?(Delivery.get_backup_riders(campaign), &(&1.id == rider.id))

--- a/test/bike_brigade_web/live/itinerary_live_test.exs
+++ b/test/bike_brigade_web/live/itinerary_live_test.exs
@@ -3,6 +3,7 @@ defmodule BikeBrigadeWeb.ItineraryLiveTest do
 
   alias BikeBrigade.Delivery
   alias BikeBrigade.LocalizedDateTime
+  alias BikeBrigade.Repo
 
   alias BikeBrigade.Repo.Seeds.Toronto
 
@@ -128,14 +129,17 @@ defmodule BikeBrigadeWeb.ItineraryLiveTest do
 
       campaign_rider = create_campaign_rider_for_test(campaign, rider)
 
-      {:ok, _task} =
+      {:ok, task} =
         Delivery.create_task_for_campaign(campaign, %{
           dropoff_name: dropoff_name,
           dropoff_location: Toronto.random_location(),
           task_items: [%{item_id: item.id, count: 1}],
-          assigned_rider_id: rider.id,
           delivery_status: :completed
         })
+
+      task
+      |> Delivery.Task.assignment_changeset(%{assigned_rider_id: rider.id})
+      |> Repo.update!()
 
       {:ok, view, html} = live(conn, ~p"/app/delivery/#{campaign_rider.token}")
 
@@ -171,11 +175,16 @@ defmodule BikeBrigadeWeb.ItineraryLiveTest do
     task_attrs = %{
       dropoff_name: dropoff_name,
       dropoff_location: Toronto.random_location(),
-      task_items: [%{item_id: item.id, count: 1}],
-      assigned_rider_id: rider.id
+      task_items: [%{item_id: item.id, count: 1}]
     }
 
     {:ok, task} = Delivery.create_task_for_campaign(campaign, task_attrs)
+
+    task =
+      task
+      |> Delivery.Task.assignment_changeset(%{assigned_rider_id: rider.id})
+      |> Repo.update!()
+
     {task, dropoff_name, item}
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -141,31 +141,34 @@ defmodule BikeBrigade.Fixtures do
     {campaign, attrs} = Map.pop_lazy(attrs, :campaign, fn -> fixture(:campaign) end)
     {rider, attrs} = Map.pop(attrs, :rider)
 
-    if rider do
-      # assign rider to campaign
+    assigned_rider_id = Map.get(attrs, :assigned_rider_id) || if(rider, do: rider.id)
+    attrs = Map.delete(attrs, :assigned_rider_id)
 
+    if assigned_rider_id do
       Delivery.create_campaign_rider(%{
         campaign_id: campaign.id,
-        rider_id: rider.id
+        rider_id: assigned_rider_id
       })
     end
 
-    rider_id = if rider, do: rider.id
-
-    # Create a task (possibly assigned to rider)
     {:ok, task} =
       Delivery.create_task_for_campaign(
         campaign,
         %{
           dropoff_name: Faker.Person.first_name(),
           dropoff_location: Toronto.random_location(),
-          task_items: [%{item_id: hd(campaign.program.items).id, count: 1}],
-          assigned_rider_id: rider_id
+          task_items: [%{item_id: hd(campaign.program.items).id, count: 1}]
         }
         |> Map.merge(attrs)
       )
 
-    task
+    if assigned_rider_id do
+      task
+      |> Delivery.Task.assignment_changeset(%{assigned_rider_id: assigned_rider_id})
+      |> Repo.update!()
+    else
+      task
+    end
   end
 
   def fixture(:opportunity, attrs) do


### PR DESCRIPTION
## Summary

Follow-up to #516 that makes rider assignment and campaign membership updates atomic and prevents tasks from referencing riders outside their campaign roster.

## Changes

- Add atomic operations for riders claiming and cancelling task signups.
- Serialize assignment, unassignment, rider removal, and automatic assignment.
- Reload and lock tasks before changing their assignment.
- Prevent generic task changesets from modifying `assigned_rider_id`.
- Record assignment history for automatic assignments.
- Handle stale concurrent LiveView actions without crashing.
- Add a composite foreign key requiring assigned riders to belong to the task’s campaign.
- Backfill campaign membership for any existing assignments missing a roster record.

## Database migration

The migration backfills missing `(campaign_id, rider_id)` membership rows, then adds:

```text
tasks(campaign_id, assigned_rider_id)
  → campaigns_riders(campaign_id, rider_id)

This provides a database-level guarantee against orphaned rider assignments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Riders can claim unassigned tasks directly during campaign signup.
  - Task assignments now record assignment history and prevent conflicting claims.
- **Bug Fixes**
  - Improved handling when assigning or unassigning tasks, including clear error messages instead of crashes.
  - Removing a rider now safely unassigns their tasks while preserving backup-rider status when applicable.
  - Prevented assignments to riders who are not members of the campaign.
- **Reliability**
  - Assignment and rider changes are processed atomically to avoid inconsistent campaign data during simultaneous updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->