### PR TITLE
Handle empty itineraries for backup riders

### DIFF
--- a/lib/bike_brigade_web/live/delivery_live/show.ex
+++ b/lib/bike_brigade_web/live/delivery_live/show.ex
@@ -12,8 +12,12 @@ defmodule BikeBrigadeWeb.DeliveryLive.Show do
 
   @impl Phoenix.LiveView
   def mount(%{"token" => token}, _session, socket) do
-    %{campaign: campaign, rider: rider, pickup_window: pickup_window} =
-      Delivery.get_campaign_rider!(token)
+    %{
+      campaign: campaign,
+      rider: rider,
+      pickup_window: pickup_window,
+      backup_rider: backup_rider
+    } = Delivery.get_campaign_rider!(token)
 
     # TODO this is hacky but will go away
 
@@ -36,6 +40,7 @@ defmodule BikeBrigadeWeb.DeliveryLive.Show do
      |> assign(:campaign_date, campaign_date)
      |> assign(:page_title, "#{campaign_name(campaign)} - #{campaign_date}")
      |> assign(:rider, rider)
+     |> assign(:backup_rider, backup_rider)
      |> assign(:active_note_task_id, nil)
      |> assign(:note_text, "")}
   end

--- a/lib/bike_brigade_web/live/delivery_live/show.html.heex
+++ b/lib/bike_brigade_web/live/delivery_live/show.html.heex
@@ -325,7 +325,7 @@
         </dl>
       </div>
     <% end %>
-    <div class="relative my-1 sm:my-2">
+    <div :if={@rider.assigned_tasks != []} class="relative my-1 sm:my-2">
       <div class="absolute inset-0 flex items-center" aria-hidden="true">
         <div class="w-full border-t border-gray-300"></div>
       </div>
@@ -335,7 +335,10 @@
         </span>
       </div>
     </div>
-    <div class="w-full overflow-hidden bg-white shadow-md sm:mt-2 sm:rounded-lg">
+    <div
+      :if={@rider.assigned_tasks != []}
+      class="w-full overflow-hidden bg-white shadow-md sm:mt-2 sm:rounded-lg"
+    >
       <div class="flex items-start space-x-1 p-2.5 bg-white border-b border-gray-200 sm:p-4">
         <div class="flex items-center justify-center flex-shrink-0 w-8 h-8 bg-green-700 rounded-full ring-8 ring-white">
           <Heroicons.star mini class="w-5 h-5 text-white" />
@@ -357,7 +360,7 @@
         </div>
       </div>
     </div>
-    <div class="relative my-1 sm:my-2">
+    <div :if={@rider.assigned_tasks != []} class="relative my-1 sm:my-2">
       <div class="absolute inset-0 flex items-center" aria-hidden="true">
         <div class="w-full border-t border-gray-300"></div>
       </div>
@@ -367,7 +370,10 @@
         </span>
       </div>
     </div>
-    <div class="overflow-hidden bg-white border-t divide-y divide-gray-200 shadow-md sm:mt-2 sm:rounded-lg">
+    <div
+      :if={@rider.assigned_tasks != []}
+      class="overflow-hidden bg-white border-t divide-y divide-gray-200 shadow-md sm:mt-2 sm:rounded-lg"
+    >
       <div class="flex flex-row items-center justify-between">
         <h2 class="text-base font-semibold text-gray-900 ml-7">
           Full Route Map
@@ -392,6 +398,13 @@
         </div>
         <br />
       </div>
+    </div>
+    <div
+      :if={@backup_rider && @rider.assigned_tasks == []}
+      id="backup-rider-empty-state"
+      class="p-4 text-center bg-white shadow-md sm:mt-2 sm:rounded-lg"
+    >
+      Thank you for signing up as a backup rider.
     </div>
   </div>
 </div>

--- a/test/bike_brigade_web/live/itinerary_live_test.exs
+++ b/test/bike_brigade_web/live/itinerary_live_test.exs
@@ -97,6 +97,52 @@ defmodule BikeBrigadeWeb.ItineraryLiveTest do
   describe "Delivery status display" do
     setup [:create_campaign, :login_as_rider]
 
+    test "shows a backup confirmation instead of a route for a backup rider without tasks", %{
+      conn: conn,
+      rider: rider,
+      campaign: campaign
+    } do
+      {:ok, campaign_rider} =
+        Delivery.create_backup_campaign_rider(%{
+          "campaign_id" => campaign.id,
+          "rider_id" => rider.id,
+          "rider_capacity" => "1",
+          "enter_building" => true,
+          "rider_signed_up" => true
+        })
+
+      {:ok, view, html} = live(conn, ~p"/app/delivery/#{campaign_rider.token}")
+
+      assert html =~ "Thank you for signing up as a backup rider."
+      assert has_element?(view, "#backup-rider-empty-state")
+      refute html =~ "Full Route Map"
+      refute has_element?(view, "iframe")
+    end
+
+    test "shows the route for a backup rider with a specific delivery", %{
+      conn: conn,
+      rider: rider,
+      campaign: campaign,
+      program: program
+    } do
+      {:ok, campaign_rider} =
+        Delivery.create_backup_campaign_rider(%{
+          "campaign_id" => campaign.id,
+          "rider_id" => rider.id,
+          "rider_capacity" => "1",
+          "enter_building" => true,
+          "rider_signed_up" => true
+        })
+
+      {_task, _dropoff_name, _item} = create_task_for_test(campaign, rider, program)
+
+      {:ok, view, html} = live(conn, ~p"/app/delivery/#{campaign_rider.token}")
+
+      assert html =~ "Full Route Map"
+      assert has_element?(view, "iframe")
+      refute has_element?(view, "#backup-rider-empty-state")
+    end
+
     test "displays Mark Complete button for unfinished tasks", %{
       conn: conn,
       rider: rider,


### PR DESCRIPTION
Hide delivery completion controls and route maps when a backup rider has no assigned tasks, avoiding invalid Google Maps destination requests. Show a backup signup confirmation instead.

Preserve the normal itinerary and route map when a backup rider also has a specific delivery assigned.

Closes #509

