### PR TITLE
Fix campaign rider conversations on mobile

### DIFF
--- a/lib/bike_brigade_web/components/conversation_component.ex
+++ b/lib/bike_brigade_web/components/conversation_component.ex
@@ -22,6 +22,12 @@ defmodule BikeBrigadeWeb.Components.ConversationComponent do
 
   @impl Phoenix.LiveComponent
   def update(%{rider: rider} = assigns, socket) do
+    assigns =
+      assigns
+      |> Map.put_new(:back_patch, ~p"/messages")
+      |> Map.put_new(:mobile_visible, assigns.live_action == :show)
+      |> Map.put_new(:show_tasks_link, true)
+
     conversation = Messaging.latest_messages(rider)
 
     earliest_timestamp =

--- a/lib/bike_brigade_web/components/conversation_component.html.heex
+++ b/lib/bike_brigade_web/components/conversation_component.html.heex
@@ -1,22 +1,22 @@
 <div
   id={"conversation-component:#{@rider.id}"}
   class={[
-    "sm:flex-1 px-1 flex-col bg-white shadow sm:rounded-lg sm:flex",
-    unless(@live_action == :show, do: "hidden", else: "flex")
+    "w-full sm:flex-1 px-1 flex-col bg-white shadow sm:rounded-lg sm:flex",
+    unless(@mobile_visible, do: "hidden", else: "flex")
   ]}
 >
   <div class="flex-grow-0 px-4 py-5 bg-white border-b border-gray-200 sm:px-6 sm:rounded-t-lg">
-    <div class="flex flex-row items-center justify-between -mt-2 -ml-4">
-      <div class="ml-4 sm:hidden">
-        <.link patch={~p"/messages"}>
+    <div class="flex items-start gap-3">
+      <div class="flex-none pt-1 sm:hidden">
+        <.link patch={@back_patch} aria-label="Back to conversations">
           <Heroicons.chevron_left class="w-6 h-6 text-indigo-600" />
         </.link>
       </div>
-      <div class="h-10 mt-2 ml-4">
+      <div class="min-w-0 flex-1">
         <h3 class="text-lg font-medium leading-6 text-gray-900">
           <%= if @rider do %>
             <div class="flex flex-col">
-              <div class="pii">
+              <div class="pii break-words">
                 <span>
                   <.link navigate={~p"/riders/#{@rider}"} class="link">
                     {@rider.name}
@@ -26,9 +26,9 @@
                   ({if @rider.pronouns, do: @rider.pronouns, else: "pronouns unknown"})
                 </span>
               </div>
-              <div class="inline-flex items-center text-sm text-gray-500 flex-shrink-1">
-                <Heroicons.device_phone_mobile mini class="w-4 h-4" />
-                <span class="pii">{@rider.phone}</span>
+              <div class="flex min-w-0 items-center text-sm text-gray-500">
+                <Heroicons.device_phone_mobile mini class="w-4 h-4 flex-none" />
+                <span class="pii break-all">{@rider.phone}</span>
               </div>
             </div>
           <% else %>
@@ -36,8 +36,12 @@
           <% end %>
         </h3>
       </div>
-      <.link patch={~p"/messages/#{@rider}/tasks"}>
-        <div class="inline-flex text-indigo-600 sm:hidden">
+      <.link
+        :if={@show_tasks_link}
+        patch={~p"/messages/#{@rider}/tasks"}
+        class="flex-none pt-1 sm:hidden"
+      >
+        <div class="inline-flex text-indigo-600">
           <Heroicons.clipboard_document_list class="inline w-6 h-6" />
         </div>
       </.link>

--- a/lib/bike_brigade_web/live/campaign_live/campaign_message_list.ex
+++ b/lib/bike_brigade_web/live/campaign_live/campaign_message_list.ex
@@ -36,6 +36,7 @@ defmodule BikeBrigadeWeb.CampaignLive.CampaignMessageList do
     {:ok,
      socket
      |> assign(:selected_rider, rider)
+     |> assign(:selected_rider_id, assigns.selected_rider_id)
      |> assign(:live_action, assigns.live_action)
      |> stream(:conversations, conversations,
        dom_id: fn {rider, _} -> "conversation-list-item:#{rider.id}" end

--- a/lib/bike_brigade_web/live/campaign_live/campaign_message_list.html.heex
+++ b/lib/bike_brigade_web/live/campaign_live/campaign_message_list.html.heex
@@ -5,7 +5,13 @@
     </div>
   <% else %>
     <div data-test-campaign-message-list class="flex h-[calc(100vh-8rem)]">
-      <div class="bg-white md:w-4/12 w-full shadow border border-gray-200 rounded-lg mr-4">
+      <div
+        id="campaign-conversation-list"
+        class={[
+          "bg-white w-full sm:w-4/12 shadow border border-gray-200 rounded-lg sm:mr-4",
+          not is_nil(@selected_rider_id) && "hidden sm:block"
+        ]}
+      >
         <.sms_message_list
           rider_link_fn={
             fn rider_id -> ~p"/campaigns/#{@campaign_id}/messaging/riders/#{rider_id}" end
@@ -14,13 +20,22 @@
         />
       </div>
 
-      <div class="flex md:w-8/12 max-h-[calc(100vh-8rem)] rounded border border-gray-200">
+      <div
+        id="campaign-conversation"
+        class={[
+          "w-full sm:w-8/12 max-h-[calc(100vh-8rem)] rounded border border-gray-200",
+          if(is_nil(@selected_rider_id), do: "hidden sm:flex", else: "flex")
+        ]}
+      >
         <.live_component
           module={ConversationComponent}
           id={@selected_rider.id}
           live_action={@live_action}
           current_user={@current_user}
           rider={@selected_rider}
+          mobile_visible={not is_nil(@selected_rider_id)}
+          back_patch={~p"/campaigns/#{@campaign_id}/messaging/riders/"}
+          show_tasks_link={false}
         />
       </div>
     </div>

--- a/test/bike_brigade_web/live/campaign_live_test.exs
+++ b/test/bike_brigade_web/live/campaign_live_test.exs
@@ -193,6 +193,37 @@ defmodule BikeBrigadeWeb.CampaignLiveTest do
       assert view |> element("a", "Rider Messaging") |> has_element?()
     end
 
+    test "can open a rider conversation and return to the campaign conversation list", ctx do
+      rider = hd(ctx.riders)
+      message = fixture(:sms_message_from_rider, rider, %{body: "A message from the rider"})
+      list_path = ~p"/campaigns/#{ctx.campaign}/messaging/riders/"
+
+      {:ok, view, _html} = live(ctx.conn, list_path)
+
+      refute has_element?(view, "#campaign-conversation-list.hidden")
+      assert has_element?(view, "#campaign-conversation.hidden")
+
+      view
+      |> element("#conversation-list-item\\:#{rider.id} a")
+      |> render_click()
+
+      assert_patched(view, ~p"/campaigns/#{ctx.campaign}/messaging/riders/#{rider}")
+      assert has_element?(view, "#campaign-conversation-list.hidden")
+      refute has_element?(view, "#campaign-conversation.hidden")
+      refute has_element?(view, "#conversation-component\\:#{rider.id}.hidden")
+      assert has_element?(view, "#message\\:#{message.id}", message.body)
+      assert has_element?(view, "#conversation-form")
+      refute has_element?(view, ~s|#campaign-conversation a[href="/messages/#{rider.id}/tasks"]|)
+
+      view
+      |> element(~s|a[aria-label="Back to conversations"][href="#{list_path}"]|)
+      |> render_click()
+
+      assert_patched(view, list_path)
+      refute has_element?(view, "#campaign-conversation-list.hidden")
+      assert has_element?(view, "#campaign-conversation.hidden")
+    end
+
     test "Can assign a rider to a task", ctx do
       rider = hd(ctx.riders)
       task = fixture(:task, %{campaign: ctx.campaign})


### PR DESCRIPTION
Show selected conversations in a mobile-friendly detail view, add back navigation, and prevent rider details from overlapping header controls.

Closes #522

## Describe your changes

<!-- Please add a link to a ticket if relevant: eg: "closes #340" -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added tests.
- [x] Are there other PRs or Issues that I should link to here?
- [x] Will this be part of a product update? If yes, please write one phrase
      about this update in the description above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved campaign messaging navigation on mobile devices.
  * Selecting a rider now opens their conversation while hiding the conversation list.
  * Added a clear “Back to conversations” link for returning to the rider list.
  * Conversation panels can now adapt their back navigation and task-link visibility based on context.

* **Bug Fixes**
  * Improved responsive layout, spacing, and rider information wrapping in conversation headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->